### PR TITLE
Temporarily remove Docker publish. Add documentation publish.

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,0 +1,58 @@
+name: Documentation
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: A released documentation version to redeploy (tag).
+        required: true
+        type: string
+
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
+# Allow reading repository contents and publishing to Github Pages.
+permissions:
+  pages: write
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    needs: release
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Checkout specified version
+        uses: actions/checkout@v3
+        with:
+          ref: refs/tags/${{ inputs.version }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
+
+      - name: Install dependencies
+        run: python -m pip install --upgrade pip setuptools wheel twine
+
+      - name: Install development tools
+        run: pip install .[tests]
+
+      - name: Generate documentation
+        run: make documentation
+
+      - name: Setup Github Pages
+        uses: actions/configure-pages@v2
+
+      - name: Upload documentation artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: docs/_generated/
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,30 +42,33 @@ jobs:
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}
 
-      - name: Wait a moment for the package to be available on PyPi
-        run: sleep 60s
-        shell: bash
-
-      - uses: docker/login-action@v2
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@v4
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-
-      - uses: docker/build-push-action@v3
-        with:
-          context: .
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          build-args: |
-            GROVE_VERSION=${{ github.ref_name }}
+      #
+      # Temporarily remove Docker container publishing
+      #
+      # - name: Wait a moment for the package to be available on PyPi
+      #   run: sleep 60s
+      #   shell: bash
+      #
+      # - uses: docker/login-action@v2
+      #   with:
+      #     registry: ${{ env.REGISTRY }}
+      #     username: ${{ github.actor }}
+      #     password: ${{ secrets.GITHUB_TOKEN }}
+      #
+      # - name: Extract metadata (tags, labels) for Docker
+      #   id: meta
+      #   uses: docker/metadata-action@v4
+      #   with:
+      #     images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+      #
+      # - uses: docker/build-push-action@v3
+      #   with:
+      #     context: .
+      #     push: true
+      #     tags: ${{ steps.meta.outputs.tags }}
+      #     labels: ${{ steps.meta.outputs.labels }}
+      #     build-args: |
+      #       GROVE_VERSION=${{ github.ref_name }}
 
   # Finally, generate and publish documentation after a successful release.
   documentation:

--- a/templates/deployment/local-quick-start/Dockerfile
+++ b/templates/deployment/local-quick-start/Dockerfile
@@ -4,5 +4,5 @@
 FROM python:3.9
 
 WORKDIR /
-COPY quick-start/test_entrypoint.sh /test_entrypoint.sh
+COPY templates/deployment/local-quick-start/test_entrypoint.sh /test_entrypoint.sh
 CMD ["bash", "/test_entrypoint.sh"]

--- a/templates/deployment/local-quick-start/test_entrypoint.sh
+++ b/templates/deployment/local-quick-start/test_entrypoint.sh
@@ -2,5 +2,7 @@
 # SPDX-License-Identifier: MPL-2.0
 
 cd app
+echo 'Installing Grove...'
 python3 setup.py install > /dev/null 2>&1
+echo 'Installation complete. Starting Grove'
 grove


### PR DESCRIPTION
## Overview

This pull-request temporarily removes Docker image building and publishing, and adds a new workflow which allows for the manual deployment of documentation from an existing tagged version.

Finally, this pull-request resolves an incorrect reference in the quick-start Dockerfile.