### PR TITLE
Migrate internal Vault secrets backend

### DIFF
--- a/grove/__about__.py
+++ b/grove/__about__.py
@@ -1,6 +1,6 @@
 """Grove metadata."""
 
-__version__ = "1.0.0rc1"
+__version__ = "1.0.0rc2"
 __title__ = "grove"
 __author__ = "HashiCorp Security (TDR)"
 __license__ = "Mozilla Public License 2.0"

--- a/grove/secrets/hashicorp_vault.py
+++ b/grove/secrets/hashicorp_vault.py
@@ -54,6 +54,14 @@ class Configuration(BaseSettings):
 
 class Handler(BaseSecret):
     def __init__(self):
+        """Sets up access to Vault.
+
+        This backend performs a pre-flight to validate that the configured token is
+        able to be used to query vault.
+
+        :raises ConfigurationException: There was an issue with configuration.
+        :raises AccessException: An issue occurred attempting to access Vault.
+        """
         self.logger = logging.getLogger(__name__)
 
         # Wrap validation errors to keep them in the Grove exception hierarchy.

--- a/grove/secrets/hashicorp_vault.py
+++ b/grove/secrets/hashicorp_vault.py
@@ -164,7 +164,7 @@ class Handler(BaseSecret):
             field, path = self.get_field_and_path(id)
         except ValueError as err:
             raise AccessException(
-                f"Secrets handler could parse the provided Vault path of {path}. {err}"
+                f"Secrets handler could parse the provided Vault path of {id}. {err}"
             )
 
         try:
@@ -182,12 +182,12 @@ class Handler(BaseSecret):
         # Return the first string value which is located using the desired name. This is
         # intended to return the first result without consideration of the engine.
         paths = [f"data.{field}", f"data.data.{field}"]
-        secret = response.json()
+        secrets = response.json()
 
-        for path in paths:
-            candidate = jmespath.search(path, secret)
-            if type(candidate) is str:
-                return candidate
+        for candidate in paths:
+            secret = jmespath.search(candidate, secrets)
+            if type(secret) is str:
+                return secret
 
         raise AccessException(
             f"Secrets handler could not get field {field} from Vault path {path}"

--- a/grove/secrets/hashicorp_vault.py
+++ b/grove/secrets/hashicorp_vault.py
@@ -1,0 +1,194 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+"""Grove HashiCorp Vault secret handler."""
+
+import logging
+import urllib.parse
+from typing import Optional, Tuple
+
+import jmespath
+import requests
+from pydantic import BaseSettings, Field, ValidationError
+
+from grove.exceptions import AccessException, ConfigurationException
+from grove.helpers import parsing
+from grove.secrets import BaseSecret
+
+
+class Configuration(BaseSettings):
+    """Defines environment variables used to configure the HashiCorp Vault handler.
+
+    This should also include any appropriate default values for fields which are not
+    required.
+    """
+
+    addr: str = Field(
+        description="The address of the Vault instance to retrieve secrets from.",
+    )
+    token: Optional[str] = Field(
+        description="An optional vault token to use when authenticating with Vault."
+    )
+    token_file: Optional[str] = Field(
+        description="An optional file to read the Vault token from."
+    )
+    namespace: Optional[str] = Field(
+        description="An optional Vault namespace that should be used."
+    )
+    api_version: str = Field(
+        description="An optional Vault API version to use (default: v1).",
+        default="v1",
+    )
+
+    class Config:
+        """Allow environment variable override of configuration fields.
+
+        This also enforce a prefix for all environment variables for this handler. As
+        an example the field `token` would be set using the environment variable
+        `GROVE_SECRET_HASHICORP_VAULT_TOKEN`.
+        """
+
+        env_prefix = "GROVE_SECRET_HASHICORP_VAULT_"
+        case_insensitive = True
+
+
+class Handler(BaseSecret):
+    def __init__(self):
+        self.logger = logging.getLogger(__name__)
+
+        # Wrap validation errors to keep them in the Grove exception hierarchy.
+        try:
+            self.config = Configuration()
+        except ValidationError as err:
+            raise ConfigurationException(parsing.validation_error(err))
+
+        # If a token file is set any value passed as a token will be overwritten with
+        # the value from file.
+        if self.config.token_file:
+            try:
+                with open(self.config.token_file, "r") as fin:
+                    self.config.token = fin.readline().strip()
+            except OSError as err:
+                raise ConfigurationException(
+                    "Secrets handler could not read Vault token the configured token "
+                    f"file of {self.config.token_file}: {err}"
+                )
+
+        # 'None' values will be automatically removed removed by requests when an HTTP
+        # call is performed.
+        self._headers = {
+            "X-Vault-Token": self.config.token,
+            "X-Vault-Request": "true",
+            "X-Vault-Namespace": self.config.namespace,
+        }
+
+        # Perform a quick pre-flight to validate whether the credentials are valid.
+        self._url = "/".join(
+            [
+                self.config.addr.rstrip("/"),
+                self.config.api_version,
+            ]
+        )
+
+        try:
+            response = requests.get(
+                f"{self._url}/auth/token/lookup-self",
+                headers=self._headers,  # type: ignore
+                allow_redirects=False,
+            )
+            response.raise_for_status()
+        except requests.exceptions.RequestException as err:
+            raise AccessException(
+                f"Secrets handler could not access Vault at {self.config.addr}: {err}"
+            )
+
+    def get_field_and_path(self, path: str) -> Tuple[str, str]:
+        """Extracts and removes 'field' parameters from a provided secret path.
+
+        :param path: The path from the connector configuration to process.
+
+        :raises VaultError: An error occurred while parsing data from the path.
+
+        :returns: A tuple containing an extracted field, if any, and a Vault API
+            compatible path.
+        """
+        url = urllib.parse.urlparse(path)
+        qs = urllib.parse.parse_qs(url.query)
+
+        # Extract and remove the field from the query parameters - if present.
+        try:
+            field = qs.pop("field", [])[0]
+        except IndexError:
+            raise ValueError("No 'field' parameter was found in the secret path.")
+
+        # Regenerate the URL without the removed parameter, removing other parameters
+        # we do not want configurable via the path.
+        url = url._replace(netloc="", scheme="", params="")
+        url = url._replace(query=urllib.parse.urlencode(qs, doseq=True))
+
+        return field, urllib.parse.urlunparse(url).lstrip("/")
+
+    def get(self, id: str) -> str:
+        """Gets and returns a secret from Vault.
+
+        To allow accessing different values under a configured secret path, this method
+        uses a non-standard convention to encode which "field" of a returned credential
+        is desired. This mimics the behavior of the Vault CLI "-field" option - though
+        this is not a supported HTTP parameter by the Vault API directly.
+
+        As an example of this, the following path would provide access to the 'password'
+        portion of a credential stored in a KVv2 engine mounted at 'secret/':
+
+            secret/data/example/demo?field=password
+
+        To instead access a 'token' portion of a credential stored in the same path, the
+        following would be used:
+
+            secret/data/example/demo?field=token
+
+        Finally, to perform the same operation against a KVv1 engine mounted at 'kv/'
+        the path is almost the same. However, the '/data/' must ALSO be dropped, as this
+        is only required for KVv2:
+
+            kv/example/demo?field=token
+
+        :param id: The path of the secret to retrieve - including engine.
+        :param name: The name of the secret, defined by the connector configuration. If
+            a 'field' is specified in the secret path this parameter will be ignored.
+
+        :raises AccessException: An issue occurred when getting the secret from Vault.
+
+        :returns: The plain-text secret from vault.
+        """
+        try:
+            field, path = self.get_field_and_path(id)
+        except ValueError as err:
+            raise AccessException(
+                f"Secrets handler could parse the provided Vault path of {path}. {err}"
+            )
+
+        try:
+            response = requests.get(
+                f"{self._url}/{path}",
+                headers=self._headers,  # type: ignore
+                allow_redirects=False,
+            )
+            response.raise_for_status()
+        except requests.exceptions.RequestException as err:
+            raise AccessException(
+                f"Secrets handler failed to read secret from Vault path {id}. {err}"
+            )
+
+        # Return the first string value which is located using the desired name. This is
+        # intended to return the first result without consideration of the engine.
+        paths = [f"data.{field}", f"data.data.{field}"]
+        secret = response.json()
+
+        for path in paths:
+            candidate = jmespath.search(path, secret)
+            if type(candidate) is str:
+                return candidate
+
+        raise AccessException(
+            f"Secrets handler could not get field {field} from Vault path {path}"
+        )

--- a/setup.py
+++ b/setup.py
@@ -69,6 +69,7 @@ setup(
         ],
         "grove.secrets": [
             "aws_ssm = grove.secrets.aws_ssm:Handler",
+            "hashicorp_vault = grove.secrets.hashicorp_vault:Handler",
         ],
     },
 )

--- a/tests/test_secrets_hashicorp_vault.py
+++ b/tests/test_secrets_hashicorp_vault.py
@@ -1,0 +1,188 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+"""Implements tests for the HashiCorp Vault secrets backend."""
+
+import json
+import os
+import re
+import tempfile
+import unittest
+
+import responses
+
+from grove.exceptions import AccessException
+from grove.secrets.hashicorp_vault import Handler
+
+
+class SecretsHashiCorpVaultTestCase(unittest.TestCase):
+    """Implements tests for the HashiCorp Vault secrets backend."""
+
+    @responses.activate
+    def setUp(self):
+        self.token = "A_VERY_SECRET_VALUE"
+
+        # Set sensible defaults for the test harness.
+        os.environ["GROVE_SECRET_HASHICORP_VAULT_ADDR"] = "http://192.0.2.1:8200"
+        os.environ["GROVE_SECRET_HASHICORP_VAULT_TOKEN"] = self.token
+
+        # Mock the pre-flight to always succeed (used to validate credentials).
+        responses.add(
+            responses.GET,
+            re.compile(r"http://.*"),
+            status=200,
+            content_type="application/json",
+            body=bytes(),
+        )
+        self.secrets = Handler()
+
+    @responses.activate
+    def test_token_from_file(self):
+        """Ensures Vault token can be read from file."""
+        expected = "THIS_IS_A_SECRET_FROM_FILE"
+
+        # Mock the pre-flight to always succeed (used to validate credentials).
+        responses.add(
+            responses.GET,
+            re.compile(r"http://.*"),
+            status=200,
+            content_type="application/json",
+            body=bytes(),
+        )
+
+        with tempfile.NamedTemporaryFile("w") as fout:
+            fout.write(expected)
+            fout.write("\n")
+            fout.flush()
+
+            # Setup a new Vault handler using this file.
+            os.environ["GROVE_SECRET_HASHICORP_VAULT_TOKEN_FILE"] = fout.name
+
+            secrets = Handler()
+
+        # Check that the token on the configured / setup secrets handler matches the
+        # value written to the temporary file.
+        self.assertEqual(secrets.config.token, expected)
+
+    @responses.activate
+    def test_client_setup(self):
+        """Ensure the client validates credentials on setup."""
+        # Pre-flight should fail if Vault is not reachable (no mock, and TEST-NET-1 URL)
+        with self.assertRaises(AccessException):
+            _ = Handler()
+
+        # Mock a successful pre-flight - used to validate credentials
+        responses.add(
+            responses.GET,
+            re.compile(r"http://.*"),
+            status=200,
+            content_type="application/json",
+            body=bytes(),
+        )
+        secrets = Handler()
+
+        # Ensure that the token on the handler matches the expected value.
+        secrets.config.token = self.token
+
+        # Mock an unsuccessful pre-flight.
+        responses.add(
+            responses.GET,
+            re.compile(r"http://.*"),
+            status=401,
+            content_type="application/json",
+            body=bytes(),
+        )
+        with self.assertRaises(AccessException):
+            _ = Handler()
+
+    @responses.activate
+    def test_get_field_and_path(self):
+        """Ensure that field and path extraction is working as expected."""
+        # Ensure fields are extracted correctly.
+        candidate = "secret/data/example/demo?field=password"
+        field, path = self.secrets.get_field_and_path(candidate)
+
+        self.assertEqual(field, "password")
+        self.assertEqual(path, "secret/data/example/demo")
+
+        # Ensure omitted fields raise an exception.
+        candidate = "secret/data/example/demo"
+        with self.assertRaises(ValueError):
+            self.secrets.get_field_and_path(candidate)
+
+    @responses.activate
+    def test_get_field_v1(self):
+        """Ensure that a KVv1 secret can be fetched."""
+        candidate = "secret/example/demo?field=password"
+        expected = "SUPER_SECRET_VALUE"
+
+        # Positive case - field and secret exists.
+        responses.add(
+            responses.GET,
+            re.compile(r"http://.*"),
+            status=200,
+            content_type="application/json",
+            body=bytes(json.dumps({"data": {"password": expected}}), "utf-8"),
+        )
+
+        secret = self.secrets.get(candidate)
+        self.assertEqual(secret, expected)
+
+        # Negative case - incorrect / missing field should raise an error.
+        responses.add(
+            responses.GET,
+            re.compile(r"http://.*"),
+            status=200,
+            content_type="application/json",
+            body=bytes(json.dumps({"data": {"unknown": expected}}), "utf-8"),
+        )
+
+        with self.assertRaises(AccessException):
+            _ = self.secrets.get(candidate)
+
+    @responses.activate
+    def test_get_error(self):
+        """Ensure authentication errors are handled."""
+        candidate = "secret/data/example/demo?field=token"
+
+        # Negative case - incorrect / missing field should raise an error.
+        responses.add(
+            responses.GET,
+            re.compile(r"http://.*"),
+            status=401,
+            content_type="application/json",
+            body=bytes(),
+        )
+
+        with self.assertRaises(AccessException):
+            _ = self.secrets.get(candidate)
+
+    @responses.activate
+    def test_get_field_v2(self):
+        """Ensure that a KVv2 secret can be fetched."""
+        candidate = "secret/data/example/demo?field=token"
+        expected = "SUPER_SECRET_VALUE_TWO"
+
+        # Positive case - field and secret exists.
+        responses.add(
+            responses.GET,
+            re.compile(r"http://.*"),
+            status=200,
+            content_type="application/json",
+            body=bytes(json.dumps({"data": {"data": {"token": expected}}}), "utf-8"),
+        )
+
+        secret = self.secrets.get(candidate)
+        self.assertEqual(secret, expected)
+
+        # Negative case - incorrect / missing field should raise an error.
+        responses.add(
+            responses.GET,
+            re.compile(r"http://.*"),
+            status=200,
+            content_type="application/json",
+            body=bytes(json.dumps({"data": {"data": {"unknown": expected}}}), "utf-8"),
+        )
+
+        with self.assertRaises(AccessException):
+            _ = self.secrets.get(candidate)


### PR DESCRIPTION
## Overview

This pull-request migrates the HashiCorp Vault secrets backend which provides support for Vault for the storage of secrets.

It should be noted that this backend requires specification of the secret to use as part of the secret path in the connector configuration document. Although this is not a field that is supported by the Vault HTTP API directly, this feature is present in the official Vault CLI using a flag of the same name:

```
vault kv get -field=token secret/example/demo
```

Assuming a Vault KV v2 Engine, the equivalent configuration snippet to populate the `key` field of a connector using this secrets backend would be :

```
"secrets": {
    "key": "secret/data/example/demo?field=token"
}
```

To make this more discoverable, a note has also been added to the doc string on the handler's `get` method, which is used to generate the Grove API documentation. An additional set of examples will be added to the Grove repository as part of the upcoming documentation updates.

This pull-request closes #12.