### PR TITLE
Add configurable delay for Google and Github.

### DIFF
--- a/grove/caches/aws_dynamodb.py
+++ b/grove/caches/aws_dynamodb.py
@@ -33,10 +33,12 @@ class Configuration(BaseSettings):
         description="The name of the AWS DynamoDB table to use for the cache.",
     )
     url: Optional[str] = Field(
-        description="An optional URL to use when connecting to AWS DynamoDB."
+        description="An optional URL to use when connecting to AWS DynamoDB.",
+        default=None,
     )
     assume_role_arn: Optional[str] = Field(
-        description="An optional AWS role to assume when authenticating with AWS."
+        description="An optional AWS role to assume when authenticating with AWS.",
+        default=None,
     )
     table_region: Optional[str] = Field(
         description="The region that the DynamoDB table exists in (default us-east-1)",

--- a/grove/configs/aws_ssm.py
+++ b/grove/configs/aws_ssm.py
@@ -30,7 +30,8 @@ class Configuration(BaseSettings):
         description="A prefix to added to the beginning of all parameter store paths.",
     )
     assume_role_arn: Optional[str] = Field(
-        description="An optional AWS role to assume when authenticating with AWS."
+        description="An optional AWS role to assume when authenticating with AWS.",
+        default=None,
     )
     ssm_region: Optional[str] = Field(
         description="The region that the parameter store exists in (default us-east-1)",

--- a/grove/configs/local_file.py
+++ b/grove/configs/local_file.py
@@ -48,7 +48,7 @@ class Handler(BaseConfig):
 
         # Wrap validation errors to keep them in the Grove exception hierarchy.
         try:
-            self.config = Configuration()
+            self.config = Configuration()  # type: ignore
         except ValidationError as err:
             raise ConfigurationException(parsing.validation_error(err))
 

--- a/grove/connectors/github/audit_log.py
+++ b/grove/connectors/github/audit_log.py
@@ -134,7 +134,7 @@ class Connector(BaseConnector):
             log = client.get_audit_log(
                 phrase=(
                     f"created:>={start.strftime(DATESTAMP_FORMAT)} "
-                    f"AND created:<={end.strftime(DATESTAMP_FORMAT)}"
+                    f"created:<={end.strftime(DATESTAMP_FORMAT)}"
                 ),
                 include=self.operation,
                 cursor=cursor,

--- a/grove/connectors/github/audit_log.py
+++ b/grove/connectors/github/audit_log.py
@@ -25,9 +25,10 @@ class Connector(BaseConnector):
     def delay(self):
         """Defines the amount of time to delay collection of logs (in minutes).
 
-        This is used to allow logs to become 'consistent'. Github backfills log entries
-        but unfortunately do not provide any guidance around 'lag' time, or consistency
-        guarantees.
+        This is used to allow time for logs to become 'consistent' before they are
+        collected. This is required as Github backfills log entries but unfortunately do
+        not provide any guidance around 'lag' time, or guarantees on availability and
+        delivery.
 
         As a result of these constraints, this value is configurable to allow operators
         to preference consistency over speed of delivery, and vice versa. For example,

--- a/grove/connectors/github/audit_log.py
+++ b/grove/connectors/github/audit_log.py
@@ -122,7 +122,7 @@ class Connector(BaseConnector):
         # Get log data from the upstream API, paging as required.
         while True:
             if end <= start:
-                self.logger.info(
+                self.logger.debug(
                     "Collection end time is prior to start, skipping.",
                     extra={
                         "start": start.strftime(DATESTAMP_FORMAT),

--- a/grove/connectors/gsuite/activities.py
+++ b/grove/connectors/gsuite/activities.py
@@ -44,9 +44,10 @@ class Connector(BaseConnector):
     def delay(self):
         """Defines the amount of time to delay collection of logs (in minutes).
 
-        This is used to allow logs to become 'consistent'. Google backfill log entries
-        based on their published lag guidelines. As a result of this, collection of
-        events within this lag window may result in missed events.
+        This is used to allow time for logs to become 'consistent' before they are
+        collected. Google backfill log entries based on their published lag guidelines.
+        As a result of this, collection of events within this lag window may result in
+        missed events.
 
         As a result of these constraints, this value is configurable to allow operators
         to preference consistency over speed of delivery, and vice versa. For example,

--- a/grove/outputs/aws_s3.py
+++ b/grove/outputs/aws_s3.py
@@ -34,7 +34,8 @@ class Configuration(BaseSettings):
         description="The name of the S3 bucket to output logs to.",
     )
     assume_role_arn: Optional[str] = Field(
-        description="An optional AWS role to assume when authenticating with AWS."
+        description="An optional AWS role to assume when authenticating with AWS.",
+        default=None,
     )
     bucket_region: Optional[str] = Field(
         description="The region that S3 the bucket exists in (default us-east-1)",
@@ -69,7 +70,7 @@ class Handler(BaseOutput):
 
         # Wrap validation errors to keep them in the Grove exception hierarchy.
         try:
-            self.config = Configuration()
+            self.config = Configuration()  # type: ignore
         except ValidationError as err:
             raise ConfigurationException(parsing.validation_error(err))
 

--- a/grove/outputs/local_file.py
+++ b/grove/outputs/local_file.py
@@ -57,7 +57,7 @@ class Handler(BaseOutput):
 
         # Wrap validation errors to keep them in the Grove exception hierarchy.
         try:
-            self.config = Configuration()
+            self.config = Configuration()  # type: ignore
         except ValidationError as err:
             raise ConfigurationException(parsing.validation_error(err))
 

--- a/grove/secrets/aws_ssm.py
+++ b/grove/secrets/aws_ssm.py
@@ -25,7 +25,8 @@ class Configuration(BaseSettings):
     """
 
     assume_role_arn: Optional[str] = Field(
-        description="An optional AWS role to assume when authenticating with AWS."
+        description="An optional AWS role to assume when authenticating with AWS.",
+        default=None,
     )
     ssm_region: Optional[str] = Field(
         description="The region that the parameter store exists in (default us-east-1)",

--- a/grove/secrets/hashicorp_vault.py
+++ b/grove/secrets/hashicorp_vault.py
@@ -27,13 +27,16 @@ class Configuration(BaseSettings):
         description="The address of the Vault instance to retrieve secrets from.",
     )
     token: Optional[str] = Field(
-        description="An optional vault token to use when authenticating with Vault."
+        description="An optional vault token to use when authenticating with Vault.",
+        default=None,
     )
     token_file: Optional[str] = Field(
-        description="An optional file to read the Vault token from."
+        description="An optional file to read the Vault token from.",
+        default=None,
     )
     namespace: Optional[str] = Field(
-        description="An optional Vault namespace that should be used."
+        description="An optional Vault namespace that should be used.",
+        default=None,
     )
     api_version: str = Field(
         description="An optional Vault API version to use (default: v1).",
@@ -66,7 +69,7 @@ class Handler(BaseSecret):
 
         # Wrap validation errors to keep them in the Grove exception hierarchy.
         try:
-            self.config = Configuration()
+            self.config = Configuration()  # type: ignore
         except ValidationError as err:
             raise ConfigurationException(parsing.validation_error(err))
 

--- a/templates/configuration/github/enterprise_audit_log.json
+++ b/templates/configuration/github/enterprise_audit_log.json
@@ -1,6 +1,7 @@
 {
     "key": "BEARER_TOKEN_HERE",
     "identity": "ENTERPRISE_NAME_HERE",
+    "delay": 10,
     "name": "github-enterprises-audit-log-example",
     "connector": "github_audit_log",
     "scope": "enterprises"

--- a/templates/configuration/github/orgs_audit_log.json
+++ b/templates/configuration/github/orgs_audit_log.json
@@ -1,6 +1,7 @@
 {
     "key": "BEARER_TOKEN_HERE",
     "identity": "ORGANIZATION_NAME_HERE",
+    "delay": 10,
     "name": "github-orgs-audit-log-example",
     "connector": "github_audit_log"
 }

--- a/templates/configuration/github/self-hosted_orgs_audit_log.json
+++ b/templates/configuration/github/self-hosted_orgs_audit_log.json
@@ -2,6 +2,7 @@
     "key": "BEARER_TOKEN_HERE",
     "identity": "ORGANIZATION_NAME_HERE",
     "name": "github-self-hosted-audit-log-example",
+    "delay": 10,
     "connector": "github_audit_log",
     "fqdn": "github.example.org"
 }

--- a/templates/configuration/gsuite/activities.json
+++ b/templates/configuration/gsuite/activities.json
@@ -2,6 +2,7 @@
     "key": "BASE64_ENCODED_SERVICE_ACCOUNT_JSON",
     "identity": "ORGANIZATION_NAME_HERE",
     "name": "gsuite-activities-example",
+    "delay": 40,
     "connector": "gsuite_activities",
     "encoding": {
         "key": "base64"


### PR DESCRIPTION
### Overview.

Per the feedback provided in #17, Google publishes estimate lag times for activity types. Collection of new log entries inside of this lag window often results in missed log entries - as the data is not yet considered consistent by the vendor.

During investigation, this was also discovered to be the case with GitHub audit logs, albeit at a much lower rate. 

As an interim work around while a more robust periodic retrospection and de-duplication process is implemented, a set of delay configuration parameters have been added to the connectors known to be affected by this sort of consistency lag.

This configuration parameter allows operations to preference consistency over collection time. As this is defined in the connector configuration, this may be specified per operation type, allowing for GSuite `login` events to have a different lag time than say `drive` events.

### Future improvements.

In future, more in-depth retrospection and de-duplication will be added which should remove the need for this parameter as log entries will instead be periodically recollected and de-duplicated to back-fill entries which were not yet present in the log at collection time.

However, as this will require a significant increase in cache operations careful consideration will need to be paid to the design and implementation of this feature.