### PR TITLE
add onepassword audit log connector

### DIFF
--- a/grove/__about__.py
+++ b/grove/__about__.py
@@ -1,6 +1,6 @@
 """Grove metadata."""
 
-__version__ = "1.0.0rc2"
+__version__ = "1.0.0rc3"
 __title__ = "grove"
 __author__ = "HashiCorp Security (TDR)"
 __license__ = "Mozilla Public License 2.0"

--- a/grove/connectors/onepassword/api.py
+++ b/grove/connectors/onepassword/api.py
@@ -8,7 +8,6 @@ import time
 from typing import Any, Dict, Optional
 
 import requests
-
 from grove.exceptions import RateLimitException, RequestFailedException
 from grove.types import AuditLogEntries, HTTPResponse
 
@@ -148,4 +147,20 @@ class Client:
         """
         return self.get_events(
             event_type="itemusages", cursor=cursor, start_time=start_time
+        )
+
+    def get_auditevents(
+        self,
+        cursor: Optional[str] = None,
+        start_time: Optional[str] = None,
+    ) -> AuditLogEntries:
+        """Fetches a list of of actions performed by team members within a 1Password account.
+
+        :param cursor: Cursor to use when fetching results. Supersedes other parameters.
+        :param start_time: The ISO Format timestamp to query logs since.
+
+        :return: AuditLogEntries object containing a pagination cursor, and log entries.
+        """
+        return self.get_events(
+            event_type="auditevents", cursor=cursor, start_time=start_time
         )

--- a/grove/connectors/onepassword/events_audit.py
+++ b/grove/connectors/onepassword/events_audit.py
@@ -1,0 +1,47 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+"""1Password Audit event log connector for Grove."""
+
+import datetime
+
+from grove.connectors import BaseConnector
+from grove.connectors.onepassword.api import Client
+from grove.constants import CHRONOLOGICAL
+from grove.exceptions import NotFoundException
+
+
+class Connector(BaseConnector):
+    NAME = "onepassword_events_audit"
+    POINTER_PATH = "timestamp"
+    LOG_ORDER = CHRONOLOGICAL
+
+    def collect(self):
+        """Collects all logs from the 1Password audit event log API.
+
+        This will first check whether there are any pointers cached to indicate previous
+        collections. If not, the last week of data will be collected.
+        """
+        client = Client(token=self.key)
+        cursor = None
+
+        # If no pointer is stored then a previous run hasn't been performed, so set the
+        # pointer to a week ago. In the case of the 1Password API this is an ISO
+        # timestamp in a field called "timestamp".
+        try:
+            _ = self.pointer
+        except NotFoundException:
+            week_ago = datetime.datetime.now() - datetime.timedelta(days=7)
+            self.pointer = (week_ago).astimezone().replace(microsecond=0).isoformat()
+
+        # Get log data from the upstream API, paging as required.
+        while True:
+            log = client.get_auditevents(start_time=self.pointer, cursor=cursor)
+
+            # Save this batch of log entries.
+            self.save(log.entries)
+
+            # Check if we need to continue paging.
+            cursor = log.cursor
+            if cursor is None:
+                break

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ setup(
             "okta_system_log = grove.connectors.okta.system_log:Connector",
             "onepassword_events_itemusages = grove.connectors.onepassword.events_itemusages:Connector",  # noqa: B950
             "onepassword_events_signinattempts = grove.connectors.onepassword.events_signinattempts:Connector",  # noqa: B950
+            "onepassword_events_audit = grove.connectors.onepassword.events_audit:Connector",  # noqa: B950
             "pagerduty_audit_records = grove.connectors.pagerduty.audit_records:Connector",
             "sf_event_log = grove.connectors.sf.event_log:Connector",
             "sfmc_audit_events = grove.connectors.sfmc.audit_events:Connector",

--- a/templates/configuration/1password/events_audit.json
+++ b/templates/configuration/1password/events_audit.json
@@ -1,0 +1,6 @@
+{
+    "key": "BEARER_TOKEN_HERE",
+    "identity": "ORGANIZATION_NAME_HERE",
+    "name": "1password-events-audit",
+    "connector": "onepassword_events_audit"
+}

--- a/tests/fixtures/onepassword/events_audit/001.json
+++ b/tests/fixtures/onepassword/events_audit/001.json
@@ -1,0 +1,78 @@
+{
+    "cursor": "aGVsbG8hIGlzIGl0IG1lIHlvdSBhcmUgbG9va2luZyBmb3IK",
+    "has_more": false,
+    "items": [
+        {
+            "uuid": "56YE2TYN2VFYRLNSHKPW5NVT5E",
+            "timestamp": "2023-03-15T16:33:50-03:00",
+            "actor_uuid": "4HCGRGYCTRQFBMGVEGTABYDU2V",
+            "action": "activate",
+            "object_type": "account",
+            "object_uuid": "56YE2TYN2VFYRLNSHKPW5NVT5E",
+            "aux_id": 0,
+            "aux_uuid": "56YE2TYN2VFYRLNSHKPW5NVT5E",
+            "aux_info": "string",
+            "session": {
+                "uuid": "A5K6COGVRVEJXJW3XQZGS7VAMM",
+                "login_time": "2023-03-15T16:33:50-03:00",
+                "device_uuid": "553aee6b-7da1-4043-84ab-86ff036035bf",
+                "ip": "192.0.2.254"
+            },
+            "location": {
+                "country": "Canada",
+                "region": "Ontario",
+                "city": "Toronto",
+                "latitude": 43.5991,
+                "longitude": -79.4988
+            }
+        },
+        {
+            "uuid": "56YE2TYN2VFYRLNSHKPW5NVT5E",
+            "timestamp": "2023-03-15T16:35:50-03:00",
+            "actor_uuid": "4HCGRGYCTRQFBMGVEGTABYDU2V",
+            "action": "activate",
+            "object_type": "account",
+            "object_uuid": "56YE2TYN2VFYRLNSHKPW5NVT5E",
+            "aux_id": 0,
+            "aux_uuid": "56YE2TYN2VFYRLNSHKPW5NVT5E",
+            "aux_info": "string",
+            "session": {
+                "uuid": "A5K6COGVRVEJXJW3XQZGS7VAMM",
+                "login_time": "2023-03-15T16:33:50-03:00",
+                "device_uuid": "553aee6b-7da1-4043-84ab-86ff036035bf",
+                "ip": "192.0.2.254"
+            },
+            "location": {
+                "country": "Canada",
+                "region": "Ontario",
+                "city": "Toronto",
+                "latitude": 43.5991,
+                "longitude": -79.4988
+            }
+        },
+        {
+            "uuid": "56YE2TYN2VFYRLNSHKPW5NVT5E",
+            "timestamp": "2023-03-15T16:50:50-03:00",
+            "actor_uuid": "4HCGRGYCTRQFBMGVEGTABYDU2V",
+            "action": "activate",
+            "object_type": "account",
+            "object_uuid": "56YE2TYN2VFYRLNSHKPW5NVT5E",
+            "aux_id": 0,
+            "aux_uuid": "56YE2TYN2VFYRLNSHKPW5NVT5E",
+            "aux_info": "string",
+            "session": {
+                "uuid": "A5K6COGVRVEJXJW3XQZGS7VAMM",
+                "login_time": "2023-03-15T16:33:50-03:00",
+                "device_uuid": "553aee6b-7da1-4043-84ab-86ff036035bf",
+                "ip": "192.0.2.254"
+            },
+            "location": {
+                "country": "Canada",
+                "region": "Ontario",
+                "city": "Toronto",
+                "latitude": 43.5991,
+                "longitude": -79.4988
+            }
+        }
+    ]
+}

--- a/tests/fixtures/onepassword/events_audit/002.json
+++ b/tests/fixtures/onepassword/events_audit/002.json
@@ -1,0 +1,30 @@
+{
+    "cursor": "aGVsbG8hIGlzIGl0IG1lIHlvdSBhcmUgbG9va2luZyBmb3IK",
+    "has_more": true,
+    "items": [
+        {
+            "uuid": "56YE2TYN2VFYRLNSHKPW5NVT5E",
+            "timestamp": "2023-03-15T16:33:50-03:00",
+            "actor_uuid": "4HCGRGYCTRQFBMGVEGTABYDU2V",
+            "action": "activate",
+            "object_type": "account",
+            "object_uuid": "56YE2TYN2VFYRLNSHKPW5NVT5E",
+            "aux_id": 0,
+            "aux_uuid": "56YE2TYN2VFYRLNSHKPW5NVT5E",
+            "aux_info": "string",
+            "session": {
+                "uuid": "A5K6COGVRVEJXJW3XQZGS7VAMM",
+                "login_time": "2023-03-15T16:33:50-03:00",
+                "device_uuid": "553aee6b-7da1-4043-84ab-86ff036035bf",
+                "ip": "192.0.2.254"
+            },
+            "location": {
+                "country": "Canada",
+                "region": "Ontario",
+                "city": "Toronto",
+                "latitude": 43.5991,
+                "longitude": -79.4988
+            }
+        }
+    ]
+}

--- a/tests/fixtures/onepassword/events_audit/003.json
+++ b/tests/fixtures/onepassword/events_audit/003.json
@@ -1,0 +1,30 @@
+{
+    "cursor": "aGVsbG8hIGlzIGl0IG1lIHlvdSBhcmUgbG9va2luZyBmb3IK",
+    "has_more": false,
+    "items": [
+        {
+            "uuid": "56YE2TYN2VFYRLNSHKPW5NVT5E",
+            "timestamp": "2023-03-15T16:33:50-03:00",
+            "actor_uuid": "4HCGRGYCTRQFBMGVEGTABYDU2V",
+            "action": "activate",
+            "object_type": "account",
+            "object_uuid": "56YE2TYN2VFYRLNSHKPW5NVT5E",
+            "aux_id": 0,
+            "aux_uuid": "56YE2TYN2VFYRLNSHKPW5NVT5E",
+            "aux_info": "string",
+            "session": {
+                "uuid": "A5K6COGVRVEJXJW3XQZGS7VAMM",
+                "login_time": "2023-03-15T16:33:50-03:00",
+                "device_uuid": "553aee6b-7da1-4043-84ab-86ff036035bf",
+                "ip": "192.0.2.254"
+            },
+            "location": {
+                "country": "Canada",
+                "region": "Ontario",
+                "city": "Toronto",
+                "latitude": 43.5991,
+                "longitude": -79.4988
+            }
+        }
+    ]
+}

--- a/tests/test_connectors_onepassword_events_audit.py
+++ b/tests/test_connectors_onepassword_events_audit.py
@@ -1,0 +1,133 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+"""Implements unit tests for the 1Password Audit Events collector."""
+
+import os
+import re
+import unittest
+from unittest.mock import patch
+
+import responses
+from grove.connectors.onepassword.events_audit import Connector
+from grove.models import ConnectorConfig
+from tests import mocks
+
+
+class OnePasswordItemUsageEventTestCase(unittest.TestCase):
+    """Implements unit tests for the 1Password Audit Events collector."""
+
+    @patch("grove.helpers.plugin.load_handler", mocks.load_handler)
+    def setUp(self):
+        """Ensure the application is setup for testing."""
+        self.dir = os.path.dirname(os.path.abspath(__file__))
+        self.connector = Connector(
+            config=ConnectorConfig(
+                identity="examplecorp",
+                key="0123456789",
+                name="examplecorp",
+                connector="test",
+            ),
+            context={
+                "runtime": "test_harness",
+                "runtime_id": "NA",
+            },
+        )
+
+    @responses.activate
+    def test_client_rate_limit(self):
+        """Ensure ratelimit waiting is working as expected."""
+        # Rate limit the first request.
+        responses.add(
+            responses.POST,
+            re.compile(r"https://.*"),
+            status=429,
+            content_type="application/json",
+            body=bytes(),
+        )
+
+        # Succeed on the second.
+        responses.add(
+            responses.POST,
+            re.compile(r"https://.*"),
+            status=200,
+            content_type="application/json",
+            body=bytes(
+                open(
+                    os.path.join(
+                        self.dir, "fixtures/onepassword/events_audit/001.json"
+                    ),
+                    "r",
+                ).read(),
+                "utf-8",
+            ),
+        )
+
+        # Ensure we sleep appropriately on rate-limit.
+        with patch("time.sleep", return_value=None) as mock_sleep:
+            self.connector.run()
+            mock_sleep.assert_called_with(1)
+
+    @responses.activate
+    def test_collect_no_pagination(self):
+        """Ensure collection without pagination is working as expected."""
+        responses.add(
+            responses.POST,
+            re.compile(r"https://.*"),
+            status=200,
+            content_type="application/json",
+            body=bytes(
+                open(
+                    os.path.join(
+                        self.dir, "fixtures/onepassword/events_audit/001.json"
+                    ),
+                    "r",
+                ).read(),
+                "utf-8",
+            ),
+        )
+
+        # Ensure only a single value is returned, and the pointer is properly set.
+        self.connector.run()
+        self.assertEqual(self.connector._saved, 3)
+        self.assertEqual(self.connector.pointer, "2023-03-15T16:50:50-03:00")
+
+    @responses.activate
+    def test_collect_pagination(self):
+        """Ensure collection with pagination is working as expected."""
+        responses.add(
+            responses.POST,
+            re.compile(r"https://.*"),
+            status=200,
+            content_type="application/json",
+            body=bytes(
+                open(
+                    os.path.join(
+                        self.dir, "fixtures/onepassword/events_audit/002.json"
+                    ),
+                    "r",
+                ).read(),
+                "utf-8",
+            ),
+        )
+
+        responses.add(
+            responses.POST,
+            re.compile(r"https://.*"),
+            status=200,
+            content_type="application/json",
+            body=bytes(
+                open(
+                    os.path.join(
+                        self.dir, "fixtures/onepassword/events_audit/003.json"
+                    ),
+                    "r",
+                ).read(),
+                "utf-8",
+            ),
+        )
+
+        # Ensure only a single value is returned, and the pointer is properly set.
+        self.connector.run()
+        self.assertEqual(self.connector._saved, 1)
+        self.assertEqual(self.connector.pointer, "2023-03-15T16:33:50-03:00")


### PR DESCRIPTION
Currently Grove has an onepassword connector. This PR adds the new Onepassword audit log feature.
  
API documentation: https://developer.1password.com/docs/events-api/reference/
