### PR TITLE
Pin `urllib3` due to `google-auth` incompatibility

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -9,6 +9,7 @@ classifiers =
 [options]
 python_requires = >= 3.9
 install_requires =
+    urllib3<2.0
     aws-lambda-powertools>=2.0,<3.0
     boto3>=1.26,<2.0
     requests>=2.28,<3.0


### PR DESCRIPTION
## Overview

This pull-request temporarily pins the version of `urllib3` to resolve incompatibility with the `google-auth` package.