### PR TITLE
Add dark mode support to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,11 +32,10 @@ us via email at security@hashicorp.com, rather than filing a GitHub issue.
 
 <p align="center">
     <br /><br />
-    <img src="docs/static/grove-support.png?raw=True" alt="Grove support overview">
     <picture>
-      <source media="(prefers-color-scheme: dark)" srcset="docs/static/grove-support.png?raw=True">
-      <source media="(prefers-color-scheme: light)" srcset="docs/static/grove-support-light.png?raw=True">
-      <img src="docs/static/grove-support-light.png?raw=True" alt="Overview of supported services, also listed below" >
+      <source media="(prefers-color-scheme: dark)" srcset="docs/static/grove-support-light.png?raw=True">
+      <source media="(prefers-color-scheme: light)" srcset="docs/static/grove-support.png?raw=True">
+      <img src="docs/static/grove-support.png?raw=True" alt="Overview of supported services, also listed below" >
     </picture>
     <br />
 </p>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 <p align="center">
     <br /><br />
-    <img src="docs/static/grove-logo-small.png?raw=True" alt="Grove">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="docs/static/grove-logo-small-light.png?raw=True">
+      <source media="(prefers-color-scheme: light)" srcset="docs/static/grove-logo-small.png?raw=True">
+      <img src="docs/static/grove-logo-small.png?raw=True" alt="Grove logo">
+    </picture>
     <br /><br />
 </p>
 
@@ -29,6 +33,11 @@ us via email at security@hashicorp.com, rather than filing a GitHub issue.
 <p align="center">
     <br /><br />
     <img src="docs/static/grove-support.png?raw=True" alt="Grove support overview">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="docs/static/grove-support.png?raw=True">
+      <source media="(prefers-color-scheme: light)" srcset="docs/static/grove-support-light.png?raw=True">
+      <img src="docs/static/grove-support-light.png?raw=True" alt="Overview of supported services, also listed below" >
+    </picture>
     <br />
 </p>
 


### PR DESCRIPTION
Add better dark mode support to the readme like described here: https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#specifying-the-theme-an-image-is-shown-to