### PR TITLE
Handle HTTP 429s from Github.

### DIFF
--- a/grove/connectors/github/api.py
+++ b/grove/connectors/github/api.py
@@ -102,8 +102,8 @@ class Client:
                 response.raise_for_status()
                 break
             except requests.exceptions.RequestException as err:
-                # 403s are used with a header to indicate rate-limit exceeded.
-                if getattr(err.response, "status_code", None) != 403:
+                # 403s OR 429s are used with a header to indicate rate-limit exceeded.
+                if int(getattr(err.response, "status_code", 0)) not in [403, 429]:
                     raise RequestFailedException(err)
 
                 if err.response.headers.get("X-RateLimit-Remaining") != "0":

--- a/tests/test_connectors_github_audit.py
+++ b/tests/test_connectors_github_audit.py
@@ -36,13 +36,49 @@ class GitHubAuditTestCase(unittest.TestCase):
         )
 
     @responses.activate
-    def test_client_rate_limit(self):
+    def test_client_rate_limit_403(self):
         """Ensure ratelimit waiting is working as expected."""
         # Rate limit the first request.
         responses.add(
             responses.GET,
             re.compile(r"https://.*"),
             status=403,
+            content_type="application/json",
+            body=bytes(),
+            headers={
+                "X-RateLimit-Remaining": "0",
+                "x-ratelimit-reset": "0",  # Unix-time, so definitely in the past :)
+            },
+        )
+
+        # Succeed on the second.
+        responses.add(
+            responses.GET,
+            re.compile(r"https://.*"),
+            status=200,
+            content_type="application/json",
+            body=bytes(
+                open(
+                    os.path.join(self.dir, "fixtures/github/audit/001.json"), "r"
+                ).read(),
+                "utf-8",
+            ),
+        )
+
+        # Ensure we sleep appropriately on rate-limit. This takes advantage of the retry
+        # logic sleeping for one second if the ratelimit-reset header is in the past.
+        with patch("time.sleep", return_value=None) as mock_sleep:
+            self.connector.run()
+            mock_sleep.assert_called_with(1)
+
+    @responses.activate
+    def test_client_rate_limit_429(self):
+        """Ensure ratelimit waiting is working as expected."""
+        # Rate limit the first request.
+        responses.add(
+            responses.GET,
+            re.compile(r"https://.*"),
+            status=429,
             content_type="application/json",
             body=bytes(),
             headers={


### PR DESCRIPTION
## Overview

This pull request ensures that both HTTP 403s responses with `x-ratelimit-remaining: 0`, as well as HTTP 429s are handled for rate limiting.

This deviates from Github's [existing documentation](https://docs.github.com/en/rest/overview/resources-in-the-rest-api?apiVersion=2022-11-28#exceeding-the-rate-limit), which states that HTTP 403s will be used with `x-ratelimit-*` headers. However, recent rate-limit blog posts from Github mention that [HTTP 429](https://github.blog/changelog/2023-07-03-new-rate-limit-is-coming-for-the-audit-log-api-endpoints/) will be used.

Speaking with Github, they have advised that both should be handled.
