### PR TITLE
Add Atlassian rate-limit handling

### DIFF
--- a/grove/__about__.py
+++ b/grove/__about__.py
@@ -1,6 +1,6 @@
 """Grove metadata."""
 
-__version__ = "1.0.0"
+__version__ = "1.0.1"
 __title__ = "grove"
 __license__ = "Mozilla Public License 2.0"
 __copyright__ = "Copyright 2023 HashiCorp, Inc."

--- a/grove/connectors/atlassian/api.py
+++ b/grove/connectors/atlassian/api.py
@@ -7,12 +7,14 @@ As Atlassian does not currently support the Events API, this client has been cre
 the interim.
 """
 
+import datetime
 import logging
+import time
 from typing import Dict, Optional
 
 import requests
 
-from grove.exceptions import RequestFailedException
+from grove.exceptions import RateLimitException, RequestFailedException
 from grove.types import AuditLogEntries, HTTPResponse
 
 API_BASE_URI = "https://api.atlassian.com/admin/v1/orgs/{identity}"
@@ -23,13 +25,17 @@ class Client:
         self,
         identity: Optional[str] = None,
         token: Optional[str] = None,
+        retry: Optional[bool] = True,
     ):
         """Setup a new client.
 
         :param identity: The name of the Atlassian organisation.
         :param token: The Atlassian API token.
+        :param retry: Automatically retry if recoverable errors are encountered, such as
+            rate-limiting.
         """
         self.logger = logging.getLogger(__name__)
+        self.retry = retry
         self.headers = {
             "Accept": "application/json",
             "Authorization": f"Bearer {token}",
@@ -48,15 +54,52 @@ class Client:
         :param url: URL to perform the HTTP GET against.
         :param params: HTTP parameters to add to the request.
 
+        :raises RateLimitException: A rate limit was encountered.
         :raises RequestFailedException: An HTTP request failed.
 
         :return: HTTP Response object containing the headers and body of a response.
         """
-        try:
-            response = requests.get(url, headers=self.headers, params=params)
-            response.raise_for_status()
-        except requests.exceptions.RequestException as err:
-            raise RequestFailedException(err)
+        while True:
+            try:
+                response = requests.get(url, headers=self.headers, params=params)
+                response.raise_for_status()
+                break
+            except requests.exceptions.RequestException as err:
+                if int(getattr(err.response, "status_code", 0)) not in [429]:
+                    raise RequestFailedException(err)
+
+                if err.response.headers.get("X-Ratelimit-Remaining") != "0":
+                    raise RequestFailedException(err)
+
+                # Retry on rate-limit, but only if requested.
+                self.logger.warning(
+                    "Rate-limit was exceeded during request",
+                    extra={
+                        "Reset-At": err.response.headers.get("X-Ratelimit-Reset"),
+                        "Limit": err.response.headers.get("X-Ratelimit-Limit"),
+                    }
+                )
+                if not self.retry:
+                    raise RateLimitException(err)
+
+                time_current = int(
+                    datetime.datetime.now(datetime.timezone.utc).strftime("%s")
+                )
+                time_ratelimit_reset = int(
+                    err.response.headers.get("X-Ratelimit-Reset", time_current)
+                )
+                time_wait = time_ratelimit_reset - time_current
+
+                # If the rate-limit retry is greater than a few of minutes, just bail as
+                # we'll pick back up at the next execution.
+                if time_wait >= 180:
+                    raise RateLimitException(err)
+
+                # Only wait for a second if the retry time was unset or in the past.
+                if time_wait > 0:
+                    time.sleep(time_wait)
+                else:
+                    time.sleep(1)
 
         return HTTPResponse(headers=response.headers, body=response.json())
 

--- a/grove/helpers/parsing.py
+++ b/grove/helpers/parsing.py
@@ -119,7 +119,7 @@ def update_path(
 
         # By default, combine the new value with the existing value(s) - making sure to
         # handle dictionaries as well as lists.
-        if key in candidate and type(candidate[key]) == list:
+        if key in candidate and isinstance(candidate[key], list):
             candidate[key].append(value)
         else:
             candidate = {**candidate, key: value}

--- a/grove/secrets/hashicorp_vault.py
+++ b/grove/secrets/hashicorp_vault.py
@@ -197,7 +197,7 @@ class Handler(BaseSecret):
 
         for candidate in paths:
             secret = jmespath.search(candidate, secrets)
-            if type(secret) is str:
+            if isinstance(secret, str):
                 return secret
 
         raise AccessException(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,7 +113,7 @@ files = [
     "./grove/**/*.py",
     "./tests/**/*.py"
 ]
-disable_error_code = "attr-defined"
+disable_error_code = "attr-defined, union-attr"
 allow_redefinition = false
 check_untyped_defs = true
 disallow_any_generics = true


### PR DESCRIPTION
## Overview

This pull-request ensures that the Atlassian connector adheres to Atlassian Cloud rate-limits. Additionally, this pull-request updates a few type annotations, and updates the handler inside of the Github connector to match the pattern used here.

Eventually, it may be best to move all rate-limit handlers into a set of core helpers for common patterns - where possible. However, as each API may be subtly different from one another this will require more analysis.