### PR TITLE
[1.1.0] Add new `filter_entries` processor

### DIFF
--- a/grove/__about__.py
+++ b/grove/__about__.py
@@ -1,6 +1,6 @@
 """Grove metadata."""
 
-__version__ = "1.0.1"
+__version__ = "1.1.0"
 __title__ = "grove"
 __license__ = "Mozilla Public License 2.0"
 __copyright__ = "Copyright 2023 HashiCorp, Inc."

--- a/grove/processors/filter_entries.py
+++ b/grove/processors/filter_entries.py
@@ -3,9 +3,9 @@
 
 """Grove processor to filter (delete) entire log entries based JMESPath queries.
 
-This processor is intended to allow dropping of log entries if a certain set of criteria
-is not met. This may be used to assist in reducing outputting noisy log entries where
-a given vendor does not provide filtering.
+This processor is intended to allow dropping of log entries when a set of criteria is
+met. This may be used to assist in reducing outputting noisy log entries where a given
+vendor does not provide a mechanism for filtering events.
 """
 
 import jmespath
@@ -29,8 +29,7 @@ class Handler(BaseProcessor):
         """Expresses the configuration and associated validators for the processor."""
 
         # Filters defines a list of JMESPath queries to be evaluated against each log
-        # entry in order. If ANY of the queries match the log entry when, then the
-        # log entry the entry will be dropped.
+        # entry in order.
         filters: List[str]
 
     def process(self, entry: Dict[str, Any]) -> List[Dict[str, Any]]:

--- a/grove/processors/filter_entries.py
+++ b/grove/processors/filter_entries.py
@@ -1,0 +1,48 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+"""Grove processor to filter (delete) entire log entries based JMESPath queries.
+
+This processor is intended to allow dropping of log entries if a certain set of criteria
+is not met. This may be used to assist in reducing outputting noisy log entries where
+a given vendor does not provide filtering.
+"""
+
+import jmespath
+from typing import Any, Dict, List
+
+from pydantic import Extra
+
+from grove.models import ProcessorConfig
+from grove.processors import BaseProcessor
+
+
+class Handler(BaseProcessor):
+    """Filter (delete) log entries based on JMESPath queries.
+
+    If any of the configured filters match a given log entry (return True), then the log
+    entry will be dropped. Queries are evaluated against log entries in the order that
+    they are defined, and the 'first match wins'.
+    """
+
+    class Configuration(ProcessorConfig, extra=Extra.forbid):
+        """Expresses the configuration and associated validators for the processor."""
+
+        # Filters defines a list of JMESPath queries to be evaluated against each log
+        # entry in order. If ANY of the queries match the log entry when, then the
+        # log entry the entry will be dropped.
+        filters: List[str]
+
+    def process(self, entry: Dict[str, Any]) -> List[Dict[str, Any]]:
+        """Drop log entries which do not match all of the configured JMESPath queries.
+
+        :param entry: A collected log entry.
+
+        :return: The processed log entry, or an empty array if the log entry should be
+            dropped.
+        """
+        for filter in self.configuration.filters:
+            if jmespath.search(filter, entry):
+                return []
+
+        return [entry]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,6 +106,7 @@ local_file = "grove.secrets.local_file:Handler"
 [project.entry-points."grove.processors"]
 extract_paths = "grove.processors.extract_paths:Handler"
 filter_paths = "grove.processors.filter_paths:Handler"
+filter_entries = "grove.processors.filter_entries:Handler"
 split_path = "grove.processors.split_path:Handler"
 
 [tool.mypy]

--- a/tests/fixtures/github/git/001.json
+++ b/tests/fixtures/github/git/001.json
@@ -1,5 +1,37 @@
 [
     {
+        "@timestamp": 1696259836406,
+        "_document_id": "YYYYXXXXZZZW",
+        "action": "git.clone",
+        "business": "example-org",
+        "business_id": 0,
+        "org": "example-org",
+        "org_id": 13371337,
+        "repo": "example-org/a-public-demo",
+        "repository": "example-org/a-public-demo",
+        "repository_public": true,
+        "transport_protocol": 1,
+        "transport_protocol_name": "http",
+        "user_agent": "git/2.25.1",
+        "user_id": 0
+    },
+    {
+        "@timestamp": 1696259836405,
+        "_document_id": "YYYYXXXXZZZX",
+        "action": "git.clone",
+        "business": "example-org",
+        "business_id": 0,
+        "org": "example-org",
+        "org_id": 13371337,
+        "repo": "example-org/a-public-demo",
+        "repository": "example-org/a-public-demo",
+        "repository_public": true,
+        "transport_protocol": 1,
+        "transport_protocol_name": "http",
+        "user_agent": "git/2.25.1",
+        "user_id": 0
+    },
+    {
         "@timestamp": 1696259836404,
         "_document_id": "YYYYXXXXZZZY",
         "action": "git.clone",

--- a/tests/fixtures/github/git/001.json
+++ b/tests/fixtures/github/git/001.json
@@ -1,0 +1,45 @@
+[
+    {
+        "@timestamp": 1696259836404,
+        "_document_id": "YYYYXXXXZZZY",
+        "action": "git.clone",
+        "business": "example-org",
+        "business_id": 0,
+        "org": "example-org",
+        "org_id": 13371337,
+        "repo": "example-org/a-public-demo",
+        "repository": "example-org/a-public-demo",
+        "repository_public": true,
+        "transport_protocol": 1,
+        "transport_protocol_name": "http",
+        "user_agent": "git/2.25.1",
+        "user_id": 0
+    },
+    {
+        "@timestamp": 1696259811869,
+        "_document_id": "YYYYXXXXZZZZ",
+        "action": "git.clone",
+        "actor": "github-actions[bot]",
+        "actor_ip": "192.0.2.1",
+        "actor_location": {
+            "country_code": "US"
+        },
+        "business": "example-org",
+        "business_id": 0,
+        "external_id": "",
+        "external_identity_nameid": "",
+        "external_identity_username": "",
+        "hashed_token": "....",
+        "org": "example-org",
+        "org_id": 13371337,
+        "programmatic_access_type": "GitHub App server-to-server token",
+        "repo": "example-org/a-private-demo",
+        "repository": "example-org/a-private-demo",
+        "repository_public": false,
+        "transport_protocol": 1,
+        "transport_protocol_name": "http",
+        "user": "",
+        "user_agent": "git/2.42.0",
+        "user_id": 0
+    }
+]

--- a/tests/test_processors_filter_entries.py
+++ b/tests/test_processors_filter_entries.py
@@ -4,7 +4,6 @@
 """Implements unit tests for the entry filtering processor."""
 
 import json
-import logging
 import os
 import unittest
 from unittest.mock import patch

--- a/tests/test_processors_filter_entries.py
+++ b/tests/test_processors_filter_entries.py
@@ -1,0 +1,52 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+"""Implements unit tests for the entry filtering processor."""
+
+import json
+import os
+import unittest
+from unittest.mock import patch
+
+from grove.models import ProcessorConfig
+from grove.processors import filter_entries
+from tests import mocks
+
+
+class ProcessorPathFilterTestCase(unittest.TestCase):
+    """Implements unit tests for the entry filtering processor."""
+
+    @patch("grove.helpers.plugin.load_handler", mocks.load_handler)
+    def setUp(self):
+        """Setup the processor and associated configuration for testing."""
+        self.dir = os.path.dirname(os.path.abspath(__file__))
+
+        # Create a mapping compatible with the Github Git log fixtures.
+        self.processor = filter_entries.Handler(
+            ProcessorConfig(
+                name="Filter entries with no actor",
+                processor="filter_entries",
+                filters=[
+                    "actor == null",
+                ],
+            )
+        )
+
+    def test_filter_entries(self):
+        """Ensure entry filtering operates as expected."""
+        # Load and process the fixture.
+        entries = json.load(
+            open(os.path.join(self.dir, "fixtures/github/git/001.json"), "r")
+        )
+
+        # Firstly, ensure two records exist to begin with.
+        self.assertEqual(len(entries), 2)
+
+        # Process all entries.
+        records = []
+        for entry in entries:
+            records.extend(self.processor.process(entry))
+
+        # Ensure records with no actor were dropped.
+        self.assertEqual(len(records), 1)
+        self.assertIn("actor", records[0])

--- a/tests/test_processors_filter_entries.py
+++ b/tests/test_processors_filter_entries.py
@@ -4,6 +4,7 @@
 """Implements unit tests for the entry filtering processor."""
 
 import json
+import logging
 import os
 import unittest
 from unittest.mock import patch
@@ -39,10 +40,9 @@ class ProcessorPathFilterTestCase(unittest.TestCase):
             open(os.path.join(self.dir, "fixtures/github/git/001.json"), "r")
         )
 
-        # Firstly, ensure two records exist to begin with.
-        self.assertEqual(len(entries), 2)
+        # Firstly, ensure four records exist to begin with.
+        self.assertEqual(len(entries), 4)
 
-        # Process all entries.
         records = []
         for entry in entries:
             records.extend(self.processor.process(entry))


### PR DESCRIPTION
### Overview

This processor allows entire log entries to be filtered from output. This is intended to assist with reducing output "noise" from vendors who do not allow filtering of audit events in a way that allows their customers to exclude certain events. This is especially useful for vendors such as Github, where Git audit events will contain log entries for interactions against public Git repositories by all Github users - but without actor information provided in these entries.

This pull-request also adjusts the log in the processor handler to allow additions and removals of entire log entries during processing, rather than just additions.