### PR TITLE
Fix up Atlassian rate-limiting.

### DIFF
--- a/grove/__about__.py
+++ b/grove/__about__.py
@@ -1,6 +1,6 @@
 """Grove metadata."""
 
-__version__ = "1.1.0"
+__version__ = "1.1.1"
 __title__ = "grove"
 __license__ = "Mozilla Public License 2.0"
 __copyright__ = "Copyright 2023 HashiCorp, Inc."

--- a/grove/connectors/atlassian/api.py
+++ b/grove/connectors/atlassian/api.py
@@ -7,18 +7,17 @@ As Atlassian does not currently support the Events API, this client has been cre
 the interim.
 """
 
-import datetime
 import logging
 import time
 from typing import Dict, Optional
-
+from datetime import datetime, timezone
 import requests
 
 from grove.exceptions import RateLimitException, RequestFailedException
 from grove.types import AuditLogEntries, HTTPResponse
 
 API_BASE_URI = "https://api.atlassian.com/admin/v1/orgs/{identity}"
-
+API_DATE_FORMAT = "%Y-%m-%dT%H:%M%z"
 
 class Client:
     def __init__(
@@ -65,41 +64,36 @@ class Client:
                 response.raise_for_status()
                 break
             except requests.exceptions.RequestException as err:
-                if int(getattr(err.response, "status_code", 0)) not in [429]:
+                if int(getattr(err.response, "status_code", 0)) != 429:
                     raise RequestFailedException(err)
 
-                if err.response.headers.get("X-Ratelimit-Remaining") != "0":
-                    raise RequestFailedException(err)
-
-                # Retry on rate-limit, but only if requested.
-                self.logger.warning(
-                    "Rate-limit was exceeded during request",
-                    extra={
-                        "Reset-At": err.response.headers.get("X-Ratelimit-Reset"),
-                        "Limit": err.response.headers.get("X-Ratelimit-Limit"),
-                    }
-                )
                 if not self.retry:
                     raise RateLimitException(err)
 
-                time_current = int(
-                    datetime.datetime.now(datetime.timezone.utc).strftime("%s")
-                )
-                time_ratelimit_reset = int(
-                    err.response.headers.get("X-Ratelimit-Reset", time_current)
-                )
-                time_wait = time_ratelimit_reset - time_current
-
-                # If the rate-limit retry is greater than a few of minutes, just bail as
-                # we'll pick back up at the next execution.
-                if time_wait >= 180:
+                # Retry on rate-limit, but only if requested or if the API does not
+                # return a reset at time.
+                reset_at = err.response.headers.get("X-Ratelimit-Reset")
+                if not reset_at:
                     raise RateLimitException(err)
 
-                # Only wait for a second if the retry time was unset or in the past.
-                if time_wait > 0:
-                    time.sleep(time_wait)
-                else:
-                    time.sleep(1)
+                self.logger.warning(
+                    "Rate-limit was exceeded during collection.",
+                    extra={
+                        "X-Ratelimit-Reset": reset_at,
+                    }
+                )
+
+                # Work out how long we need to wait, and if too long, just bail early.
+                time_current = int(datetime.now(timezone.utc).strftime("%s"))
+                time_reset = int(datetime.strptime(reset_at, API_DATE_FORMAT).strftime("%s")) # noqa: E501
+                time_wait = time_reset - time_current
+
+                if time_wait >= 180:
+                    raise RateLimitException(err)
+                if time_wait <= 0:
+                    continue
+
+                time.sleep(time_wait)
 
         return HTTPResponse(headers=response.headers, body=response.json())
 


### PR DESCRIPTION
### Overview

Atlassian have a number of rate-limiters which differ depending on the API. This commit ensures that the rate-limit handler for the Admin API operates as expected.