### PR TITLE
[v1.2.2] Fix Oomntiza pagination size, Okta rate-limiting

### DIFF
--- a/grove/connectors/okta/api.py
+++ b/grove/connectors/okta/api.py
@@ -109,7 +109,7 @@ class Client:
                 if getattr(err.response, "status_code", None) != 429:
                     raise RequestFailedException(err)
 
-                if err.response.headers.get("X-RateLimit-Remaining") != "0":
+                if err.response.headers.get("X-Rate-Limit-Remaining") != "0":
                     raise RequestFailedException(err)
 
                 # Retry on rate-limit, but only if requested.

--- a/grove/connectors/oomnitza/api.py
+++ b/grove/connectors/oomnitza/api.py
@@ -12,7 +12,7 @@ from grove.exceptions import RequestFailedException
 from grove.types import AuditLogEntries, HTTPResponse
 
 API_BASE_URI = "https://{identity}.oomnitza.com"
-API_PAGE_SIZE = 200
+API_PAGE_SIZE = 2000
 
 
 class Client:

--- a/tests/test_connectors_oomnitza_activities.py
+++ b/tests/test_connectors_oomnitza_activities.py
@@ -36,6 +36,7 @@ class OomnitzaAuditTestCase(unittest.TestCase):
         )
 
     @responses.activate
+    @patch("grove.connectors.oomnitza.api.API_PAGE_SIZE", 200)
     def test_collect_pagination(self):
         """Ensure pagination is working as expected."""
         responses.add(


### PR DESCRIPTION
## Overview

This pull-request adjusts the Oomnitza page-size to ensure that collection can complete in a timely manner during large integration runs. Additionally, this pull-request fixes a typo in the Okta rate-limit handler to ensure that rate-limits are correctly handled.