### PR TITLE
[1.3.0] Add Python 3.12 support. Fix Google tests.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ macos-latest, ubuntu-latest ]
-        python-version: [ '3.9', '3.10' ]
+        python-version: [ '3.9', '3.10', '3.12' ]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,9 @@ jobs:
       matrix:
         os: [ macos-latest, ubuntu-latest ]
         python-version: [ '3.9', '3.10', '3.12' ]
+        exclude:
+          - os: macos-latest
+            python-version: '3.9'
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4

--- a/grove/__about__.py
+++ b/grove/__about__.py
@@ -1,6 +1,6 @@
 """Grove metadata."""
 
-__version__ = "1.2.2"
+__version__ = "1.3.0"
 __title__ = "grove"
 __license__ = "Mozilla Public License 2.0"
 __copyright__ = "Copyright 2023 HashiCorp, Inc."

--- a/grove/helpers/plugin.py
+++ b/grove/helpers/plugin.py
@@ -20,7 +20,13 @@ def lookup_handler(name: str, group: str) -> EntryPoint:
 
     :raises ConfigurationException: The specified handler could not be located.
     """
-    for candidate in entry_points().select(group=group):
+    # Handle differences between importlib in Python 3.9, 3.10, and Python 3.12.
+    try:
+        entrypoints = entry_points().select(group=group)
+    except AttributeError:
+        entrypoints = entry_points().get(group, ())  # type: ignore
+
+    for candidate in entrypoints:
         if candidate.name == name:
             return candidate
 

--- a/grove/helpers/plugin.py
+++ b/grove/helpers/plugin.py
@@ -20,13 +20,7 @@ def lookup_handler(name: str, group: str) -> EntryPoint:
 
     :raises ConfigurationException: The specified handler could not be located.
     """
-    # The 'group' kwarg for entry_points was added in Python 3.10, in order to support
-    # older versions of Python 3 we will not be using this feature. Additionally, using
-    # get() will raise deprecation warnings to use select() instead. However, select()
-    # was also added in Python 3.10, which would break backwards compatibility...
-    eps = entry_points()
-
-    for candidate in eps.get(group, []):
+    for candidate in entry_points().select(group=group):
         if candidate.name == name:
             return candidate
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,6 @@ dependencies = [
     "twilio>=7.15,<8.0",
     "pydantic>=1.10,<2.0",
     "jmespath>=1.0.0,<2.0",
-    "importlib_metadata>=6.0,<7.0",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,7 +115,7 @@ files = [
     "./grove/**/*.py",
     "./tests/**/*.py"
 ]
-disable_error_code = "attr-defined, union-attr"
+disable_error_code = "attr-defined, union-attr, unused-ignore"
 allow_redefinition = false
 check_untyped_defs = true
 disallow_any_generics = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ tests = [
     "tox",
     "sphinx",
     "furo",
-    "moto[s3,ssm]",
+    "moto[s3,ssm]>=4.0,<5.0",
     "types-requests",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "twilio>=7.15,<8.0",
     "pydantic>=1.10,<2.0",
     "jmespath>=1.0.0,<2.0",
+    "importlib_metadata>=6.0,<7.0",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_connectors_gsuite_activities.py
+++ b/tests/test_connectors_gsuite_activities.py
@@ -5,8 +5,9 @@
 
 import os
 import unittest
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
+from google.auth.credentials import Credentials
 from googleapiclient.http import HttpMockSequence
 
 from grove.connectors.gsuite.activities import Connector
@@ -40,11 +41,15 @@ class GSuiteActivitiesTestCase(unittest.TestCase):
             },
         )
 
-    @patch("google.oauth2.service_account.Credentials.from_service_account_info")
     @patch("googleapiclient.discovery.build")
+    @patch("grove.connectors.gsuite.activities.Connector.get_credentials")
     @patch("grove.connectors.gsuite.activities.Connector.get_http_transport")
-    def test_collect_pagination(self, mock_transport, mock_request, mock_auth):
+    def test_collect_pagination(self, mock_transport, mock_auth, mock_request):
         """Ensure collection works as expected."""
+        credentials = Mock(spec=Credentials)
+        credentials.universe_domain = "googleapis.com"
+
+        mock_auth.return_value = credentials
         mock_transport.return_value = MockSequence(
             [
                 (

--- a/tests/test_connectors_gsuite_alerts.py
+++ b/tests/test_connectors_gsuite_alerts.py
@@ -5,8 +5,9 @@
 
 import os
 import unittest
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
+from google.auth.credentials import Credentials
 from googleapiclient.http import HttpMockSequence
 
 from grove.connectors.gsuite.alerts import Connector
@@ -39,11 +40,15 @@ class GSuiteAlertsTestCase(unittest.TestCase):
             },
         )
 
-    @patch("google.oauth2.service_account.Credentials.from_service_account_info")
     @patch("googleapiclient.discovery.build")
+    @patch("grove.connectors.gsuite.alerts.Connector.get_credentials")
     @patch("grove.connectors.gsuite.alerts.Connector.get_http_transport")
-    def test_collect_pagination(self, mock_transport, mock_request, mock_auth):
+    def test_collect_pagination(self, mock_transport, mock_auth, mock_request):
         """Ensure collection works as expected."""
+        credentials = Mock(spec=Credentials)
+        credentials.universe_domain = "googleapis.com"
+        mock_auth.return_value = credentials
+
         mock_transport.return_value = MockSequence(
             [
                 (


### PR DESCRIPTION
## Overview

This pull-request adds support for Python 3.12. It also resolves current issues with tests failing for the Google Workspace connectors after a change in the Google SDK.
