### PR TITLE
[1.3.1] Increase Google Workspace Alert page size

### DIFF
--- a/grove/__about__.py
+++ b/grove/__about__.py
@@ -1,6 +1,6 @@
 """Grove metadata."""
 
-__version__ = "1.3.0"
+__version__ = "1.3.1"
 __title__ = "grove"
 __license__ = "Mozilla Public License 2.0"
 __copyright__ = "Copyright 2023 HashiCorp, Inc."

--- a/grove/connectors/gsuite/alerts.py
+++ b/grove/connectors/gsuite/alerts.py
@@ -68,6 +68,7 @@ class Connector(BaseConnector):
 
         # Page over all alerts since the last pointer.
         more_requests = True
+        page_size = 1000
 
         with build("alertcenter", "v1beta1", http=http) as service:
             while more_requests:
@@ -82,19 +83,18 @@ class Connector(BaseConnector):
                         extra={"cursor": cursor},
                     )
                     request = service.alerts().list(
-                        orderBy="createTime asc", pageToken=cursor
+                        orderBy="createTime asc",
+                        pageSize=page_size,
+                        pageToken=cursor,
                     )
                 else:
-                    # Google's APIs return timestamps with microseconds, as a result the
-                    # potential for two records to occur at the same time and one be
-                    # missed is EXTREMELY low. As a result, we'll use > rather than >=
-                    # here.
                     self.logger.debug(
                         "Using createTime from pointer",
                         extra={"pointer": self.pointer},
                     )
                     request = service.alerts().list(
                         orderBy="createTime asc",
+                        pageSize=page_size,
                         filter=f'createTime > "{self.pointer}"',
                     )
 


### PR DESCRIPTION
## Overview

This pull request increases the number of alerts returned by Google Workspace Alerts per page.

This is a temporary mitigation for a strange error encountered with the Google Workspace API where pagination returns 400 errors, despite the requests being performed using the pagination token returned by the API, and using the official Google Python SDK.

We will look to open a bug report with Google around this behaviour.

