### PR TITLE
[1.4.0] Add remote HTTP output handler.

### DIFF
--- a/grove/__about__.py
+++ b/grove/__about__.py
@@ -1,6 +1,6 @@
 """Grove metadata."""
 
-__version__ = "1.3.1"
+__version__ = "1.4.0"
 __title__ = "grove"
 __license__ = "Mozilla Public License 2.0"
 __copyright__ = "Copyright 2023 HashiCorp, Inc."

--- a/grove/helpers/parsing.py
+++ b/grove/helpers/parsing.py
@@ -109,7 +109,12 @@ def update_path(
     # Set the value on the last recursion.
     if len(path) < 1:
         if value is None:
-            del candidate[key]
+            try:
+                del candidate[key]
+            except KeyError:
+                # We don't need to do anything if the key doesn't exist.
+                pass
+
             return candidate
 
         # If replace is set, don't combine the new value with the existing.

--- a/grove/outputs/remote_http.py
+++ b/grove/outputs/remote_http.py
@@ -1,0 +1,170 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+"""Grove remote HTTP output handler."""
+
+import json
+from typing import Any, Dict, List, Optional
+
+import requests
+from pydantic import Field
+
+from grove.constants import GROVE_METADATA_KEY
+from grove.exceptions import AccessException, DataFormatException
+from grove.outputs import BaseOutput
+
+
+class Handler(BaseOutput):
+    class Configuration(BaseOutput.Configuration):
+        """Defines environment variables used to configure the remote HTTP handler.
+
+        This should also include any appropriate default values for fields which are not
+        required.
+        """
+
+        url: str = Field(
+            description="The fully-qualified URL to POST logs to",
+        )
+        retries: int = Field(
+            description="The maximum number of retries before failing the collection.",
+            default=5,
+        )
+        headers: Optional[str] = Field(
+            description="A pipe delimited set of HTTP headers to add ('key: value').",
+            default=None,
+        )
+        timeout: int = Field(
+            description="The maximum time to wait before a request times out (seconds)",
+            default=10,
+        )
+        insecure: bool = Field(
+            description="Whether to accept invalid certificates for HTTPS endpoints.",
+            default=False,
+        )
+
+        class Config:
+            """Allow environment variable override of configuration fields.
+
+            This also enforce a prefix for all environment variables for this handler.
+            As an example the field `url` would be set using the environment variable
+            `GROVE_OUTPUT_REMOTE_HTTP_URL`.
+            """
+
+            env_prefix = "GROVE_OUTPUT_REMOTE_HTTP_"
+            case_insensitive = True
+
+    def setup(self):
+        """Parses and sets up HTTP headers.
+
+        This method parses pipe delimited HTTP headers from the environment. This is not
+        perfect, but we're relatively limited when using environment variables while
+        wishing to retain compatibility across runtimes.
+        """
+        # The content-type can be updated by the caller, if they wish.
+        self._headers = {
+            "Content-Type": "application/x-ndjson",
+        }
+
+        # Construct the headers from the configured pipe delimeted values.
+        if self.config.headers:
+            for header in self.config.headers.split("|"):
+                key = header.split(":")[0]
+                value = ":".join(header.split(":")[1:]).lstrip(" ")
+
+                # Downcase for comparison to ensure we don't add duplicates.
+                for existing in self._headers.copy().keys():
+                    # Delete the old value entirely if there is one present.
+                    if existing.lower() == key.lower():
+                        del self._headers[existing]
+
+                    # Add the new value.
+                    self._headers[key] = value
+
+    def submit(
+        self,
+        data: bytes,
+        connector: str,
+        identity: str,
+        operation: str,
+        part: int = 0,
+        kind: Optional[str] = None,
+        descriptor: Optional[str] = None,
+    ):
+        """Performs an HTTP POST with the body containing collected logs as NDJSON.
+
+        :param data: Log data to POST.
+        :param connector: Name of the connector which retrieved the data.
+        :param identity: Identity the collected data was collect for.
+        :param operation: Operation the collected logs are associated with.
+        :param part: Number indicating which part of the same log stream this file
+            contains data for.
+        :param kind: Currently not used by this output plugin.
+        :param descriptor: Currently not used by this output plugin.
+
+        :raises AccessException: An issue occurred when writing data.
+        """
+        attempts = 0
+
+        # Whether we need to verify certificates. We define this here to avoid negating
+        # booleans or using ternaries later on which may lead to confusion later.
+        verify = True
+
+        if self.config.insecure == True:  # noqa: E712
+            verify = False
+
+        # Only attempt to POST the configured number of times, otherwise bail and allow
+        # retry on next collection.
+        while attempts < self.config.retries:
+            try:
+                response = requests.post(
+                    self.config.url,
+                    data=data,
+                    headers=self._headers,
+                    timeout=self.config.timeout,
+                    verify=verify,
+                )
+
+                # Break out of the retry look on success, otherwise loop and retry.
+                response.raise_for_status()
+                break
+            except requests.exceptions.RequestException as err:
+                attempts += 1
+
+                if attempts >= self.config.retries:
+                    raise AccessException(
+                        f"Unable to submit log data to HTTP endpoint: {err}"
+                    )
+
+    def serialize(self, data: List[Any], metadata: Dict[str, Any] = {}) -> bytes:
+        """Implements serialization of log entries to NDJSON.
+
+        :param data: A list of log entries to serialize to JSON.
+        :param metadata: Metadata to append to each log entry before serialization. If
+            not specified no metadata will be added.
+
+        :return: Log data serialized as NDJSON (as bytes).
+
+        :raises DataFormatException: Cannot serialize the input to JSON.
+        """
+        candidate = []
+
+        # Append the Grove metadata to each log entry, and serialize to JSON.
+        for entry in data:
+            # Skip empty log entries.
+            if entry is None:
+                continue
+
+            if metadata:
+                entry[GROVE_METADATA_KEY] = {
+                    **metadata,
+                    **entry.get(GROVE_METADATA_KEY, {}),
+                }
+
+            # We don't want to silently drop and lose single records, so drop the entire
+            # batch if there is bad data (which will trigger a retry next run).
+            try:
+                candidate.append(json.dumps(entry, separators=(",", ":")))
+            except TypeError as err:
+                raise DataFormatException(f"Unable to serialize to JSON: {err}")
+
+        return bytes("\r\n".join(candidate), "utf-8")

--- a/grove/outputs/remote_http.py
+++ b/grove/outputs/remote_http.py
@@ -65,7 +65,7 @@ class Handler(BaseOutput):
             "Content-Type": "application/x-ndjson",
         }
 
-        # Construct the headers from the configured pipe delimeted values.
+        # Construct the headers from the configured pipe delimited values.
         if self.config.headers:
             for header in self.config.headers.split("|"):
                 key = header.split(":")[0]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,6 +95,7 @@ local_memory = "grove.caches.local_memory:Handler"
 aws_s3 = "grove.outputs.aws_s3:Handler"
 local_file = "grove.outputs.local_file:Handler"
 local_stdout = "grove.outputs.local_stdout:Handler"
+remote_http = "grove.outputs.remote_http:Handler"
 
 [project.entry-points."grove.configs"]
 aws_ssm = "grove.configs.aws_ssm:Handler"

--- a/tests/test_outputs_remote_http.py
+++ b/tests/test_outputs_remote_http.py
@@ -1,0 +1,137 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+"""Implements tests for the remote HTTP output handler."""
+
+import os
+import re
+import unittest
+
+import responses
+
+from grove.exceptions import AccessException
+from grove.outputs.remote_http import Handler
+
+
+class RemoteHTTPOutputTestCase(unittest.TestCase):
+    """Implements tests for the remote HTTP output handler."""
+
+    def setUp(self):
+        os.environ["GROVE_OUTPUT_REMOTE_HTTP_URL"] = "https://192.0.2.1"
+        os.environ["GROVE_OUTPUT_REMOTE_HTTP_HEADERS"] = (
+            "content-type: test/fixture|Example: My-Example"
+        )
+
+        self.handler = Handler()
+        self.handler.setup()
+
+    def test_setup(self):
+        """Ensures headers are correctly set."""
+        EXPECTED_HEADERS = {
+            "Content-Type": "test/fixture",
+            "Example": "My-Example",
+        }
+
+        # Ensure the headers are processed correctly.
+        self.assertDictEqual(EXPECTED_HEADERS, self.handler._headers)
+
+    @responses.activate
+    def test_submit_retry_failure(self):
+        """Ensures an error is raised after the maximum retry count is exceeded."""
+        DEFAULT_RETRIES = 5
+
+        # Simulate the default number of failures.
+        for _ in range(0, DEFAULT_RETRIES):
+            responses.add(
+                responses.POST,
+                re.compile(r"https://.*"),
+                status=500,
+                content_type="application/json",
+                body=bytes(),
+            )
+
+        with self.assertRaises(AccessException):
+            self.handler.submit(
+                data=bytes("{}", "utf-8"),
+                connector="X",
+                identity="Y",
+                operation="Z",
+            )
+
+        # Ensure we only attempted the configured number of times.
+        self.assertEqual(len(responses.calls), DEFAULT_RETRIES)
+
+    @responses.activate
+    def test_submit_success(self):
+        """Ensures no errors on successful POST."""
+        responses.add(
+            responses.POST,
+            re.compile(r"https://.*"),
+            status=200,
+            content_type="application/json",
+            body=bytes(),
+        )
+
+        self.handler.submit(
+            data=bytes("{}", "utf-8"),
+            connector="X",
+            identity="Y",
+            operation="Z",
+        )
+
+        # Ensure we submitted on the first attempt.
+        self.assertEqual(len(responses.calls), 1)
+
+    @responses.activate
+    def test_submit_after_retry(self):
+        """Ensures no errors if a successful POST is seen after a retry."""
+        WANTED_TRIES = 3
+
+        for _ in range(0, WANTED_TRIES - 1):
+            responses.add(
+                responses.POST,
+                re.compile(r"https://.*"),
+                status=500,
+                content_type="application/json",
+                body=bytes(),
+            )
+
+        responses.add(
+            responses.POST,
+            re.compile(r"https://.*"),
+            status=200,
+            content_type="application/json",
+            body=bytes(),
+        )
+
+        self.handler.submit(
+            data=bytes("{}", "utf-8"),
+            connector="X",
+            identity="Y",
+            operation="Z",
+        )
+
+        self.assertEqual(len(responses.calls), WANTED_TRIES)
+
+    def test_serialize(self):
+        """Ensures serialization into NDJSON is functional."""
+        candidate = [
+            {"id": "0001", "name": "One"},
+            {"id": "0002", "name": "Two"},
+            {"id": "0003", "name": "Three"},
+        ]
+
+        # Manually constructed.
+        expected_raw = "\r\n".join(
+            [
+                '{"id":"0001","name":"One","_grove":{"field":"value"}}',
+                '{"id":"0002","name":"Two","_grove":{"field":"value"}}',
+                '{"id":"0003","name":"Three","_grove":{"field":"value"}}',
+            ]
+        )
+        expected_raw = bytes(expected_raw, "utf-8")
+
+        self.assertEqual(
+            expected_raw,
+            self.handler.serialize(data=candidate, metadata={"field": "value"}),
+        )

--- a/tests/test_outputs_remote_http.py
+++ b/tests/test_outputs_remote_http.py
@@ -28,7 +28,7 @@ class RemoteHTTPOutputTestCase(unittest.TestCase):
     def test_setup(self):
         """Ensures headers are correctly set."""
         EXPECTED_HEADERS = {
-            "Content-Type": "test/fixture",
+            "content-type": "test/fixture",
             "Example": "My-Example",
         }
 


### PR DESCRIPTION
### Overview

This pull-request adds an initial remote HTTP output handler. This output handler allows collected logs to be submitted to a configured HTTP / HTTPS endpoint via HTTP POST in ND-JSON format.

Additionally, this pull-request resolves a small bug in the the `filter_paths` processor, which raises a KeyError when a configured path to drop does not exist. This is a minor bug which only occurs in very specific configurations.

This pull-request is in response to the ask from #47.

### Handler Configuration
In order to maximise compatibility, this handler provides the following configuration options:

* `GROVE_OUTPUT_REMOTE_HTTP_URL`
    * **Description**: The URL to POST collected logs to.
    * **Example**: `https://192.0.2.1/some/endpoint`
* `GROVE_OUTPUT_REMOTE_HTTP_HEADERS`
    * **Description**: An optional set of pipe ('|') delimited HTTP headers, in 'key: value' format.
    * **Example**: `Content-Type: application/something|Authorization: 1234abcdef=`
* `GROVE_OUTPUT_REMOTE_HTTP_RETRIES`
    * **Description**: The number of times to attempt a POST before failing _[default: 5]_.
    * **Example**: `10`
* `GROVE_OUTPUT_REMOTE_HTTP_TIMEOUT`
    * **Description**: The amount of time before an attempted POST fails _[default: 10s]_.
    * **Example**: `20`
* `GROVE_OUTPUT_REMOTE_HTTP_INSECURE`
    * **Description**: Disables certificate verification (insecure!) _[default: False]_
    * **Example**: `True`