### PR TITLE
fix: migrates docker images to python:3.9-slim

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,4 +26,10 @@ jobs:
       - run: pip install . # required for e2e tests
       - run: make lint
       - run: tox
-      - run: docker build . --file Dockerfile -t grove
+
+      # Although this won't execute on macOS, the Docker build should be the same
+      # across all OS. In future we may wish to ensure this runs on macOS, but
+      # for the time being ensuring the build completes on any system should be
+      # enough to confirm the Docker image is working.
+      - if: matrix.os != 'macos-latest'
+        run: docker build . --file Dockerfile -t grove

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,3 +26,4 @@ jobs:
       - run: pip install . # required for e2e tests
       - run: make lint
       - run: tox
+      - run: docker build . --file Dockerfile -t grove

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
-FROM python:3.9-alpine
+FROM python:3.9-slim
 
 RUN pip install --no-cache-dir grove
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,11 +6,11 @@ services:
   grove:
     build:
       context: .
-      dockerfile: templates/deployment/local-quick-start/Dockerfile
+      dockerfile: Dockerfile
     environment:
       GROVE_OUTPUT_HANDLER: "local_stdout"
       GROVE_CONFIG_HANDLER: "local_file"
       GROVE_CACHE_HANDLER: "local_memory"
-      GROVE_CONFIG_LOCAL_FILE_PATH: "/app/local-quick-start/connectors"
+      GROVE_CONFIG_LOCAL_FILE_PATH: "/app/templates/deployment/local-quick-start/connectors"
     volumes:
       - .:/app

--- a/templates/deployment/local-quick-start/Dockerfile
+++ b/templates/deployment/local-quick-start/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
-FROM python:3.9
+FROM python:3.9-slim
 
 WORKDIR /
 COPY templates/deployment/local-quick-start/test_entrypoint.sh /test_entrypoint.sh


### PR DESCRIPTION
## Context

When [following the instructions in the project README](https://github.com/hashicorp-forge/grove?tab=readme-ov-file#quick-start) to `docker compose up` to get started, I experienced a few build and run issues. These appear to be related to the [infamous compatibility inconsistencies with python projects and docker alpine images](https://pythonspeed.com/articles/alpine-docker-python/). I took a pass at remedying the issue by switching the images to python:3.9-slim and switching the docker compose to reference the root dockerfile, and this fixed the build and runtime issues getting started with Grove.

## Changes

- Migrates docker images from alpine to python:3.9-slim due to build failures caused by wheels incompatibility in the alpine based images
- Updates docker compose to use main Dockerfile due to failing runs referencing a non-existent setup.py file
- Adds github actions step that validates the Docker image builds successfully