### PR TITLE
Add local file backed cache handler.

### DIFF
--- a/grove/caches/local_file.py
+++ b/grove/caches/local_file.py
@@ -1,0 +1,189 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+"""Grove local file cache handler."""
+
+import logging
+import os
+from typing import Optional
+
+from pydantic import BaseSettings, Field, ValidationError
+
+from grove.caches import BaseCache
+from grove.exceptions import (
+    AccessException,
+    ConfigurationException,
+    DataFormatException,
+    NotFoundException,
+)
+from grove.helpers import parsing
+
+CACHE_PATH = "{pk}/{sk}.cache"
+
+
+class Configuration(BaseSettings):
+    """Defines environment variables used to configure the local file cache handler.
+
+    This should also include any appropriate default values for fields which are not
+    required.
+    """
+
+    path: str = Field(
+        description="The path to the directory to write cache data to.",
+    )
+
+    class Config:
+        """Allow environment variable override of configuration fields.
+
+        This also enforce a prefix for all environment variables for this handler.
+        As an example the field `path` would be set using the environment variable
+        `GROVE_CACHE_LOCAL_FILE_PATH`.
+        """
+
+        env_prefix = "GROVE_CACHE_LOCAL_FILE_"
+        case_insensitive = True
+
+
+class Handler(BaseCache):
+    """A local file backed cache for pointers and other Grove data."""
+
+    def __init__(self):
+        self.logger = logging.getLogger(__name__)
+
+        # Wrap validation errors to keep them in the Grove exception hierarchy.
+        try:
+            self.config = Configuration()
+        except ValidationError as err:
+            raise ConfigurationException(parsing.validation_error(err))
+
+    def get(self, pk: str, sk: str) -> str:
+        """Retrieve a value from a local file backed cache with the given key.
+
+        :param pk: Partition key of the value to retrieve.
+        :param sk: Sort key of the value to retrieve.
+
+        :raises NotFoundException: No value was found.
+
+        :return: Value from the cache.
+        """
+        path = os.file.join(self.config.path, CACHE_PATH.format(pk=pk, sk=sk))
+        value = None
+
+        try:
+            with open(path, "r") as hndl:
+                value = hndl.read()
+        except FileNotFoundError:
+            # If the file isn't found, we treat this as the cache is empty for this
+            # PK / SK, so we can just drop through and let the is None handler take
+            # care of this for us.
+            pass
+        except OSError as err:
+            raise AccessException(
+                "Unable to read cache entry.",
+                extra={
+                    "pk": pk,
+                    "sk": sk,
+                    "path": path,
+                    "exception": err,
+                },
+            )
+
+        if value is None:
+            self.logger.info("No value found in cache", extra={"pk": pk, "sk": sk})
+            raise NotFoundException("No value found in cache")
+
+        return value
+
+    def set(
+        self,
+        pk: str,
+        sk: str,
+        value: str,
+        not_set: bool = False,
+        constraint: Optional[str] = None,
+    ):
+        """Stores the value for the given key in a local file backed cache.
+
+        :param pk: Partition key of the value to save.
+        :param sk: Sort key of the value to save.
+        :param value: Value to save.
+        :param not_set: Specifies whether the value must not already be set in the cache
+            for the set to be successful.
+        :param constraint: An optional condition to use set operation. If provided,
+            the currently cached value must match for the delete to be successful.
+
+        :raises ValueError: An incompatible set of parameters were provided.
+        :raises DataFormatException: The provided constraint was not satisfied.
+        """
+        path = os.file.join(self.config.path, CACHE_PATH.format(pk=pk, sk=sk))
+
+        if constraint is not None and not_set:
+            raise ValueError("A value cannot both have a constraint AND not be set.")
+
+        # First check if the value is set, and if so whether the caller requires that it
+        # NOT already be set.
+        try:
+            current = self.get(pk, sk)
+        except FileNotFoundError:
+            pass
+
+        if current and not_set:
+            raise DataFormatException("Value is already set in cache")
+
+        # Next check if the constraint is met.
+        if constraint is not None and current != constraint:
+            raise DataFormatException("Current value in cache did not match constraint")
+
+        # Finally, set the value.
+        try:
+            with open(path, "w") as hndl:
+                hndl.truncate()
+                hndl.write(value)
+        except OSError as err:
+            raise AccessException(
+                "Unable to write cache entry.",
+                extra={
+                    "pk": pk,
+                    "sk": sk,
+                    "path": path,
+                    "exception": err,
+                },
+            )
+
+    def delete(self, pk: str, sk: str, constraint: Optional[str] = None):
+        """Deletes an entry from local file backed cache that has the given key.
+
+        :param pk: Partition key of the value to delete.
+        :param sk: Sort key of the value to delete.
+        :param constraint: An optional condition to use during the delete. The value
+            provided as the condition must match for the delete to be successful.
+
+        :raises DataFormatException: The provided constraint was not satisfied.
+        """
+        # To enforce constraints, we first need the current value - if any.
+        current = None
+        path = os.file.join(self.config.path, CACHE_PATH.format(pk=pk, sk=sk))
+
+        try:
+            current = self.get(pk, sk)
+        except FileNotFoundError:
+            pass
+
+        # Next check if the constraint is met.
+        if constraint is not None and current != constraint:
+            raise DataFormatException("Current value in cache did not match constraint")
+
+        try:
+            os.unlink(path)
+        except FileNotFoundError:
+            pass
+        except OSError as err:
+            raise AccessException(
+                "Unable to delete cache entry.",
+                extra={
+                    "pk": pk,
+                    "sk": sk,
+                    "path": path,
+                    "exception": err,
+                },
+            )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,6 +92,7 @@ oomnitza_activities = "grove.connectors.oomnitza.activities:Connector"
 [project.entry-points."grove.caches"]
 aws_dynamodb = "grove.caches.aws_dynamodb:Handler"
 local_memory = "grove.caches.local_memory:Handler"
+local_file = "grove.caches.local_file:Handler"
 
 [project.entry-points."grove.outputs"]
 aws_s3 = "grove.outputs.aws_s3:Handler"

--- a/tests/test_caches_local_file.py
+++ b/tests/test_caches_local_file.py
@@ -1,0 +1,82 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+"""Implements tests for the local file backed cache handler."""
+
+import os
+import tempfile
+import unittest
+
+from grove.caches.local_file import Handler
+from grove.exceptions import DataFormatException, NotFoundException
+
+
+class LocalFileCacheTestCase(unittest.TestCase):
+    """Implements tests for the local file backed cache handler."""
+
+    def setUp(self):
+        """Create temporary directories before each test."""
+        self.path = tempfile.TemporaryDirectory()
+        os.environ["GROVE_CACHE_LOCAL_FILE_PATH"] = self.path.name
+
+    def tearDown(self):
+        """Clean-up temporary directories after each test."""
+        self.path.cleanup()
+
+    def test_delete(self):
+        """Ensures our delete operations match expectations."""
+        handler = Handler()
+
+        # Ensures we can delete existing cache values.
+        expected = "0000"
+
+        handler.set("test", "fixture", expected)
+        handler.delete("test", "fixture")
+
+        # Ensures we can delete existing cache values - with constraint.
+        expected = "0001"
+        handler.set("test", "fixture", expected)
+        handler.delete("test", "fixture", constraint=expected)
+
+        # Ensures deletion failes if the constraint doesn't match.
+        expected = "0002"
+
+        handler.set("test", "fixture", expected)
+        with self.assertRaises(DataFormatException):
+            handler.delete("test", "fixture", constraint="0000")
+
+    def test_get(self):
+        """Ensures our get operations match expectations."""
+        handler = Handler()
+
+        # Ensure a non-existent value raises.
+        with self.assertRaises(NotFoundException):
+            handler.get("test", "fixture")
+
+        # Ensures values can be set and get, returning the correct value.
+        expected = "0000"
+
+        handler.set("test", "fixture", expected)
+        candidate = handler.get("test", "fixture")
+
+        self.assertEqual(candidate, expected)
+
+    def test_set(self):
+        """Ensures our set operations match expectations."""
+        handler = Handler()
+
+        # Set a value with no constraints.
+        handler.set("test", "fixture", "0000")
+
+        # Ensure not_set is working as expected.
+        handler.set("test", "fixture", "0001", not_set=False)
+        with self.assertRaises(DataFormatException):
+            handler.set("test", "fixture", "0002", not_set=True)
+
+        # Ensure constraints are working as expected.
+        handler.set("test", "fixture", "0003", constraint="0001")
+        with self.assertRaises(DataFormatException):
+            handler.set("test", "fixture", "0004", constraint="____")
+
+        # Ensure constraints and not_set are working together.
+        handler.set("test", "fixture", "0005", constraint="0003", not_set=False)


### PR DESCRIPTION
## Overview

This pull-request adds a local file backed cache handler.

This enables much easier local testing of connectors, and can be used to enable "one-shot" style use by analysts during incident response. This works by caching the values locally in flat files, allowing Grove to read back these files and understand where the last collection was up to.

As there is no locking, this should likely not be used in production, but it may be used in a pinch if required.