### PR TITLE
Move Dockerfile to build current source, rather than release.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ COPY grove grove/
 COPY pyproject.toml .
 
 # Install Grove from sources, and clean-up.
-RUN pip install --no-cache-dir /tmp/grove
-RUN rm -rf /tmp/grove
+RUN pip install --no-cache-dir /tmp/grove && \
+    rm -rf /tmp/grove
 
 ENTRYPOINT ["grove"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,15 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
-FROM python:3.9-slim
+FROM python:3.12-slim
 
-RUN pip install --no-cache-dir grove
+# Copy in Grove ready for installation.
+WORKDIR /tmp/grove
+COPY grove grove/
+COPY pyproject.toml .
+
+# Install Grove from sources, and clean-up.
+RUN pip install --no-cache-dir /tmp/grove
+RUN rm -rf /tmp/grove
 
 ENTRYPOINT ["grove"]


### PR DESCRIPTION
## Overview

Per the feedback from #52 , this pull-request moves the Dockerfile to installing Grove from the currently checked out sources, rather than the released version from PyPi.

This also moves the container to Python 3.12 by default.