### PR TITLE
add fixes to gsuite connector

### DIFF
--- a/grove/connectors/__init__.py
+++ b/grove/connectors/__init__.py
@@ -74,6 +74,7 @@ class BaseConnector:
         self.identity = self.configuration.identity
         self.operation = self.configuration.operation
         self.name = self.configuration.name
+        self.subject = getattr(self.configuration, 'subject', None)
 
         # Define contextual log data to be appended to all log messages.
         self.log_context = {

--- a/grove/connectors/gsuite/activities.py
+++ b/grove/connectors/gsuite/activities.py
@@ -215,8 +215,9 @@ class Connector(BaseConnector):
             credentials = service_account.Credentials.from_service_account_info(
                 service_account_info,
                 scopes=SCOPES,
-                subject=self.identity,
+                subject=self.subject,
             )
+            credentials = credentials.with_subject(self.subject)
         except ValueError as err:
             raise ConfigurationException(
                 "Unable to generate credentials from service account info for "

--- a/grove/connectors/gsuite/alerts.py
+++ b/grove/connectors/gsuite/alerts.py
@@ -149,7 +149,7 @@ class Connector(BaseConnector):
             credentials = service_account.Credentials.from_service_account_info(
                 service_account_info,
                 scopes=SCOPES,
-                subject=self.identity,
+                subject=self.subject,
             )
         except ValueError as err:
             raise ConfigurationException(
@@ -158,3 +158,4 @@ class Connector(BaseConnector):
             )
 
         return credentials
+


### PR DESCRIPTION
- Updates the connector for Google Workspaces (formerly GSuite) to use a "subject" field expected with credentials
  - see ["Domain-wide delegation"](https://google-auth.readthedocs.io/en/master/reference/google.oauth2.service_account.html)
 
The subject field should be associated with a service account which has domain-wide delegation.