### PR TITLE
🐛 Dropbox Team Events are in chronological order

### DIFF
--- a/grove/connectors/dropbox/team_events.py
+++ b/grove/connectors/dropbox/team_events.py
@@ -7,14 +7,14 @@ import datetime
 
 from grove.connectors import BaseConnector
 from grove.connectors.dropbox.api import Client
-from grove.constants import OPERATION_DEFAULT, REVERSE_CHRONOLOGICAL
+from grove.constants import OPERATION_DEFAULT, CHRONOLOGICAL
 from grove.exceptions import NotFoundException
 
 
 class Connector(BaseConnector):
     CONNECTOR = "dropbox_team_events"
     POINTER_PATH = "timestamp"
-    LOG_ORDER = REVERSE_CHRONOLOGICAL
+    LOG_ORDER = CHRONOLOGICAL
 
     @property
     def client_id(self):

--- a/tests/fixtures/dropbox/team_events/002.json
+++ b/tests/fixtures/dropbox/team_events/002.json
@@ -85,7 +85,7 @@
                     }
                 }
             ],
-            "timestamp": "2017-01-25T15:51:20Z"
+            "timestamp": "2017-01-25T15:51:00Z"
         }
     ],
     "has_more": true

--- a/tests/test_connectors_dropbox_team_events.py
+++ b/tests/test_connectors_dropbox_team_events.py
@@ -176,4 +176,4 @@ class DropboxTeamEventsTestCase(unittest.TestCase):
         # Ensure only a single value is returned, and the pointer is properly set.
         self.connector.run()
         self.assertEqual(self.connector._saved["logs"], 2)
-        self.assertEqual(self.connector.pointer, "2017-01-25T15:51:20Z")
+        self.assertEqual(self.connector.pointer, "2017-01-25T15:51:10Z")


### PR DESCRIPTION
## Overview

It appears that Dropbox Team Events are returned in chronological order. This is good news, save for that the current implementation was based on them being in reverse chronological order - which is incorrect.