### PR TITLE
Zitadel connector

### DIFF
--- a/grove/connectors/zitadel/__init__.py
+++ b/grove/connectors/zitadel/__init__.py
@@ -1,0 +1,1 @@
+"""grove-connectors-zitadel-events."""

--- a/grove/connectors/zitadel/events.py
+++ b/grove/connectors/zitadel/events.py
@@ -4,15 +4,17 @@
 """Zitadel Events connector for Grove."""
 
 import time
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 import requests
+
 from grove.connectors import BaseConnector
 from grove.constants import CHRONOLOGICAL
-from grove.exceptions import NotFoundException, RequestFailedException
-
-
-# Zitadel Events API allows you to retrieve all events based on a given aggregate event type
+from grove.exceptions import (
+    NotFoundException,
+    RateLimitException,
+    RequestFailedException,
+)
 
 
 class Connector(BaseConnector):
@@ -21,64 +23,116 @@ class Connector(BaseConnector):
     LOG_ORDER = CHRONOLOGICAL
     RATE_LIMIT_WINDOW = 60
 
-    def configure(self):
-        self._host = self.configuration.identity
-        self._pat = self.configuration.key
+    @property
+    def batch_size(self) -> int:
+        """Fetches the batch size from the configuration.
 
-        self._batch_size = self.configuration.batch_size
-        self._timeout = self.configuration.timeout
-        self._event_types = self.configuration.aggregate_event_types
+        :return: The "batch_size" portion of the connector's configuration.
+        """
+        try:
+            return self.configuration.batch_size
+        except AttributeError:
+            return 10
 
-    def _build_headers(self) -> Dict[str, str]:
-        return {
-            "Authorization": f"Bearer {self._pat}",
-            "Content-Type": "application/json",
-        }
+    @property
+    def timeout(self) -> int:
+        """Fetches the request timeout from the configuration - in seconds.
+
+        :return: The "timeout" portion of the connector's configuration.
+        """
+        try:
+            return self.configuration.timeout
+        except AttributeError:
+            return 100
+
+    @property
+    def aggregate_event_types(self) -> List[str]:
+        """Fetches a list of aggregate event types from the configuration.
+
+        :return: A list of "aggregate_event_types" from the connector's configuration.
+        """
+        try:
+            return self.configuration.aggregate_event_types
+        except AttributeError:
+            return []
 
     def _build_query(self, last_sequence: Optional[str] = None) -> Dict[str, Any]:
-        query = {
-            "limit": self._batch_size,
+        """Convenience method to construct a Zitadel API request body.
+
+        :param last_sequence: An optional sequence number to query events after.
+
+        :return: A dictionary expressing a Zitadel API request body.
+        """
+        query: Dict[str, Any] = {
+            "limit": self.batch_size,
             "asc": True,
         }
 
-        if self._event_types:
-            query["aggregateTypes"] = self._event_types
-            
+        if self.aggregate_event_types:
+            query["aggregateTypes"] = self.aggregate_event_types
+
         if last_sequence:
             query["sequence"] = last_sequence
 
         return query
 
     def _make_request(self, query: Dict[str, Any]) -> Optional[Dict[str, Any]]:
-        url = f"{self._host.rstrip('/')}/admin/v1/events/_search"
-    
-        try:
-            response = requests.post(
-                url,
-                headers=self._build_headers(),
-                json=query,
-                timeout=self._timeout,
-            )
-            response.raise_for_status()
+        """Convenience method to perform an HTTP request to collect events.
 
-        except requests.exceptions.HTTPError as err:
-            if response.status_code == 429:
-                retry_after = int(response.headers.get("Retry-After", self.RATE_LIMIT_WINDOW))
-                time.sleep(retry_after)
-                return self._make_request(query)
-            raise RequestFailedException(f"Request failed: {err}")
+        :param query: A set of parameters to be provided as the query to the API.
+
+        :return: The results from the Zitadel API for the provided query.
+        """
+        host = self.configuration.identity.rstrip("/")
+        url = f"{host}/admin/v1/events/_search"
+        retries = 5
+        attempts = 0
+
+        while True:
+            try:
+                response = requests.post(
+                    url,
+                    headers={
+                        "Authorization": f"Bearer {self.configuration.key}",
+                        "Content-Type": "application/json",
+                    },
+                    json=query,
+                    timeout=self.timeout,
+                )
+                response.raise_for_status()
+                break
+            except requests.exceptions.HTTPError as err:
+                if response.status_code == 429:
+                    if attempts < retries:
+                        time.sleep(
+                            int(
+                                response.headers.get(
+                                    "Retry-After",
+                                    self.RATE_LIMIT_WINDOW,
+                                )
+                            )
+                        )
+                        attempts += 1
+                    else:
+                        raise RateLimitException(err)
+
+                    continue
+
+                raise RequestFailedException(f"Request failed: {err}")
 
         try:
-            _ = response.json()  
+            _ = response.json()
         except requests.exceptions.JSONDecodeError:
             return None
 
-        return response.json()  
-
+        return response.json()
 
     def collect(self):
-        self.configure()  
+        """Collects events from the Zitadel API.
 
+        This will first check whether there are any pointers cached to indicate previous
+        collections. If not, all data will be collected.
+        """
         try:
             _ = self.pointer
         except NotFoundException:
@@ -95,4 +149,3 @@ class Connector(BaseConnector):
             self.save(events)
 
             has_more = result.get("pagination", {}).get("has_more", False)
-

--- a/grove/connectors/zitadel/events.py
+++ b/grove/connectors/zitadel/events.py
@@ -1,0 +1,120 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+"""Zitadel Events connector for Grove."""
+
+import json
+import time
+from typing import Any, Dict, Optional
+
+import requests
+from grove.connectors import BaseConnector
+from grove.constants import CHRONOLOGICAL
+from grove.exceptions import ConfigurationException, NotFoundException, RequestFailedException
+
+
+# Zitadel Events API allows you to retrieve all events based on a given aggregate event type
+
+
+class Connector(BaseConnector):
+    CONNECTOR = "zitadel_events_aggregate_user"
+    POINTER_PATH = "sequence"
+    LOG_ORDER = CHRONOLOGICAL
+    RATE_LIMIT_WINDOW = 60
+
+    def configure(self):
+        self._host = self.configuration.identity
+        if not self._host:
+            raise ConfigurationException("Missing required 'identity' parameter")
+        
+        self._pat = self.configuration.key
+        if not self._pat:
+            raise ConfigurationException("Missing required 'key' parameter")
+
+        self._batch_size = self.configuration.batch_size
+        self._timeout = self.configuration.timeout
+        self._event_types = self.configuration.aggregate_event_types
+
+    def _build_headers(self) -> dict:
+        print('this is the pat', self._pat)
+        return {
+            "Authorization": f"Bearer {self._pat}",
+            "Content-Type": "application/json",
+        }
+
+    def _build_query(self, last_sequence: Optional[str] = None) -> Dict[str, Any]:
+        query = {
+            "limit": self._batch_size,
+            "asc": True,
+        }
+
+        if self._event_types:
+            query["aggregateTypes"] = self._event_types
+            
+        if last_sequence:
+            query["sequence"] = last_sequence
+
+        return query
+
+    def _make_request(self, query: dict) -> dict:
+        url = f"{self._host.rstrip('/')}/admin/v1/events/_search"
+       
+        try:
+            print("Request URL:", url)
+            print("Request Headers:", json.dumps(self._build_headers(), indent=2))
+            print("Request Body:", json.dumps(query, indent=2))
+            response = requests.post(
+                url,
+                headers=self._build_headers(),
+                json=query,
+                timeout=self._timeout,
+            )
+            print("Response status code:", response.status_code)  # Prints 200
+            print("Response text:", response.text)  # Prints raw response content
+            response.raise_for_status()
+
+            # If the response is JSON, parse it
+            try:
+                response_data = response.json()
+                print("Response JSON:", response_data)
+            except requests.exceptions.JSONDecodeError:
+                print("Response is not JSON.")
+
+        except requests.exceptions.HTTPError as err:
+            if response.status_code == 429:
+                retry_after = int(response.headers.get("Retry-After", self.RATE_LIMIT_WINDOW))
+                time.sleep(retry_after)
+                return self._make_request(query)
+            raise RequestFailedException(f"Request failed: {err}")
+
+        return response.json()
+
+    def collect(self):
+        self.configure()  # Ensure configuration is set up before collecting
+
+        try:
+            _ = self.pointer
+        except NotFoundException:
+            self.pointer = "0"
+
+        cursor = str(self.pointer) if self.pointer else None
+        has_more = True
+
+        while has_more:
+            try:
+                query = self._build_query(cursor)
+                result = self._make_request(query)
+                
+                events = result.get("events", [])
+   
+                if not events:
+                    print("no new events found")
+                    break
+
+                self.save(events)
+                cursor = max(cursor or "0", max(event.get("sequence", "0") for event in events))
+                self.pointer = cursor
+                has_more = result.get("pagination", {}).get("has_more", False)
+                
+            except RequestFailedException as err:
+                break

--- a/grove/connectors/zitadel/events.py
+++ b/grove/connectors/zitadel/events.py
@@ -24,11 +24,7 @@ class Connector(BaseConnector):
 
     def configure(self):
         self._host = self.configuration.identity
-
-        
         self._pat = self.configuration.key
-        if not self._pat:
-            raise ConfigurationException("Missing required 'key' parameter")
 
         self._batch_size = self.configuration.batch_size
         self._timeout = self.configuration.timeout

--- a/grove/connectors/zitadel/events.py
+++ b/grove/connectors/zitadel/events.py
@@ -24,8 +24,7 @@ class Connector(BaseConnector):
 
     def configure(self):
         self._host = self.configuration.identity
-        if not self._host:
-            raise ConfigurationException("Missing required 'identity' parameter")
+
         
         self._pat = self.configuration.key
         if not self._pat:

--- a/grove/connectors/zitadel/events.py
+++ b/grove/connectors/zitadel/events.py
@@ -3,14 +3,13 @@
 
 """Zitadel Events connector for Grove."""
 
-import json
 import time
 from typing import Any, Dict, Optional
 
 import requests
 from grove.connectors import BaseConnector
 from grove.constants import CHRONOLOGICAL
-from grove.exceptions import ConfigurationException, NotFoundException, RequestFailedException
+from grove.exceptions import NotFoundException, RequestFailedException
 
 
 # Zitadel Events API allows you to retrieve all events based on a given aggregate event type

--- a/grove/connectors/zitadel/events.py
+++ b/grove/connectors/zitadel/events.py
@@ -31,7 +31,6 @@ class Connector(BaseConnector):
         self._event_types = self.configuration.aggregate_event_types
 
     def _build_headers(self) -> dict:
-        print('this is the pat', self._pat)
         return {
             "Authorization": f"Bearer {self._pat}",
             "Content-Type": "application/json",
@@ -55,25 +54,19 @@ class Connector(BaseConnector):
         url = f"{self._host.rstrip('/')}/admin/v1/events/_search"
        
         try:
-            print("Request URL:", url)
-            print("Request Headers:", json.dumps(self._build_headers(), indent=2))
-            print("Request Body:", json.dumps(query, indent=2))
             response = requests.post(
                 url,
                 headers=self._build_headers(),
                 json=query,
                 timeout=self._timeout,
             )
-            print("Response status code:", response.status_code)  # Prints 200
-            print("Response text:", response.text)  # Prints raw response content
             response.raise_for_status()
 
             # If the response is JSON, parse it
             try:
                 response_data = response.json()
-                print("Response JSON:", response_data)
             except requests.exceptions.JSONDecodeError:
-                print("Response is not JSON.")
+                return None
 
         except requests.exceptions.HTTPError as err:
             if response.status_code == 429:
@@ -82,7 +75,7 @@ class Connector(BaseConnector):
                 return self._make_request(query)
             raise RequestFailedException(f"Request failed: {err}")
 
-        return response.json()
+        return response_data
 
     def collect(self):
         self.configure()  # Ensure configuration is set up before collecting

--- a/grove/connectors/zitadel/events.py
+++ b/grove/connectors/zitadel/events.py
@@ -29,7 +29,7 @@ class Connector(BaseConnector):
         self._timeout = self.configuration.timeout
         self._event_types = self.configuration.aggregate_event_types
 
-    def _build_headers(self) -> dict:
+    def _build_headers(self) -> Dict[str, str]:
         return {
             "Authorization": f"Bearer {self._pat}",
             "Content-Type": "application/json",
@@ -49,7 +49,7 @@ class Connector(BaseConnector):
 
         return query
 
-    def _make_request(self, query: dict) -> dict:
+    def _make_request(self, query: Dict[str, Any]) -> Optional[Dict[str, Any]]:
         url = f"{self._host.rstrip('/')}/admin/v1/events/_search"
     
         try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,6 +94,8 @@ workday_activity_logging = "grove.connectors.workday.activity_logging:Connector"
 zoom_activities = "grove.connectors.zoom.activities:Connector"
 zoom_operationlogs = "grove.connectors.zoom.operationlogs:Connector"
 oomnitza_activities = "grove.connectors.oomnitza.activities:Connector"
+zitadel_events = "grove.connectors.zitadel.events:Connector"
+
 
 
 [project.entry-points."grove.caches"]

--- a/templates/configuration/zitadel/zitadel_events_user.json
+++ b/templates/configuration/zitadel/zitadel_events_user.json
@@ -1,0 +1,11 @@
+{
+        "name": "zitadel_events",
+        "identity": "",
+        "connector": "zitadel_events",
+        "key": "",
+        "batch_size": 10,
+        "timeout": 120,
+        "aggregate_event_types": ["user"]
+    
+}
+

--- a/tests/test_connectors_zitadel_events.py
+++ b/tests/test_connectors_zitadel_events.py
@@ -1,0 +1,124 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+"""Implements unit tests for the Zitadel Events connector."""
+
+
+import os
+import unittest
+from unittest.mock import patch, MagicMock
+import responses
+from responses import matchers
+import re
+from grove.connectors.zitadel.events import Connector
+from grove.models import ConnectorConfig
+from grove.exceptions import ConfigurationException, RequestFailedException
+from tests import mocks
+
+
+class ZitadelEventsTestCase(unittest.TestCase):
+    """Implements unit tests for the Zitadel Events connector."""
+
+    @patch("grove.helpers.plugin.load_handler", mocks.load_handler)
+    def setUp(self):
+        """Ensure the application is setup for testing."""
+        self.dir = os.path.dirname(os.path.abspath(__file__))
+        self.connector = Connector(
+            config=ConnectorConfig(
+                identity="https://zitadel.example.com",
+                key="test_pat",
+                batch_size=100,
+                timeout=30,
+                aggregate_event_types=["user.created", "user.updated"],
+            ),
+            context={
+                "runtime": "test_harness",
+                "runtime_id": "NA",
+            },
+        )
+
+    def test_configure_missing_identity(self):
+        """Ensure configure raises an exception if identity is missing."""
+        self.connector.configuration.identity = None
+        with self.assertRaises(ConfigurationException):
+            self.connector.configure()
+
+    def test_configure_missing_key(self):
+        """Ensure configure raises an exception if key is missing."""
+        self.connector.configuration.key = None
+        with self.assertRaises(ConfigurationException):
+            self.connector.configure()
+
+    @responses.activate
+    def test_collect_success(self):
+        """Ensure collect works as expected when API returns valid data."""
+        responses.add(
+            responses.POST,
+            re.compile(r"https://zitadel\.example\.com/admin/v1/events/_search"),
+            json={
+                "events": [{"sequence": "1", "type": "user.created"}],
+                "next_sequence": "2",
+            },
+            status=200,
+            content_type="application/json",
+        )
+
+        self.connector.pointer = "0"
+        self.connector.save = MagicMock()
+
+        self.connector.collect()
+
+        self.connector.save.assert_called_once_with(
+            [{"sequence": "1", "type": "user.created"}]
+        )
+
+    @responses.activate
+    def test_collect_rate_limit(self):
+        """Ensure collect handles rate-limiting correctly."""
+        responses.add(
+            responses.POST,
+            re.compile(r"https://zitadel\.example\.com/admin/v1/events/_search"),
+            status=429,
+            headers={"Retry-After": "1"},
+        )
+
+        self.connector.pointer = "0"
+        with self.assertRaises(RequestFailedException):
+            self.connector.collect()
+
+    @responses.activate
+    def test_collect_server_error(self):
+        """Ensure collect raises an exception on server error."""
+        responses.add(
+            responses.POST,
+            re.compile(r"https://zitadel\.example\.com/admin/v1/events/_search"),
+            status=500,
+        )
+
+        self.connector.pointer = "0"
+        with self.assertRaises(RequestFailedException):
+            self.connector.collect()
+
+    def test_build_headers(self):
+        """Ensure headers are built correctly."""
+        headers = self.connector._build_headers()
+        self.assertEqual(
+            headers,
+            {
+                "Authorization": "Bearer test_pat",
+                "Content-Type": "application/json",
+            },
+        )
+
+    def test_build_query(self):
+        """Ensure query is built correctly."""
+        query = self.connector._build_query(last_sequence="10")
+        self.assertEqual(
+            query,
+            {
+                "limit": 100,
+                "asc": True,
+                "sequence": "10",
+                "aggregate_event_types": ["user.created", "user.updated"],
+            },
+        )


### PR DESCRIPTION
This PR adds a custom connector for retrieving events using the [Zitadel Events API](https://zitadel.com/docs/guides/integrate/zitadel-apis/event-api) for the authentication management service, [Zitadel](https://zitadel.com/)


- You will need to know which [Aggregate Event Types]([AggregateTypesList](https://zitadel.com/docs/apis/resources/admin)) to query for and use these in the `"aggregate_event_types"` field in the configuration object
- You will need to enter the FQDN for your Zitadel instance for the the `identity` field in the configuration object