### PR TITLE
Fix default PagerDuty pointer

### DIFF
--- a/grove/__about__.py
+++ b/grove/__about__.py
@@ -1,6 +1,6 @@
 """Grove metadata."""
 
-__version__ = "2.0.0"
+__version__ = "2.1.0"
 __title__ = "grove"
 __license__ = "Mozilla Public License 2.0"
 __copyright__ = "Copyright 2025 HashiCorp, Inc."

--- a/grove/connectors/pagerduty/audit_records.py
+++ b/grove/connectors/pagerduty/audit_records.py
@@ -30,11 +30,13 @@ class Connector(BaseConnector):
         # If no pointer is stored then a previous run hasn't been performed, so set the
         # pointer to a week ago. In the case of the PagerDuty audit API the pointer is
         # the value of the "execution_time" field from the latest record retrieved from
-        # the API - which is in ISO8601 Format.
+        # the API.
         try:
             _ = self.pointer
         except NotFoundException:
-            self.pointer = (datetime.utcnow() - timedelta(days=7)).isoformat()
+            since = datetime.now(tz=timezone.utc) - timedelta(days=7)
+            since = since.replace(tzinfo=None)
+            self.pointer = since.isoformat(timespec="milliseconds") + "Z"
 
         # Get log data from the upstream API, paging as required.
         while True:

--- a/grove/connectors/pagerduty/audit_records.py
+++ b/grove/connectors/pagerduty/audit_records.py
@@ -3,7 +3,7 @@
 
 """PagerDuty Audit connector for Grove."""
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from grove.connectors import BaseConnector
 from grove.connectors.pagerduty.api import Client


### PR DESCRIPTION
## Overview

This pull-request fixes up the default pointer for PagerDuty, which uses a different date-time format than was defined. This only affects the first ever collection, so this change should not impact existing users.