### PR TITLE
Move debug log messages to debug. Genericise exception handlers.

### DIFF
--- a/grove/caches/aws_dynamodb.py
+++ b/grove/caches/aws_dynamodb.py
@@ -142,7 +142,7 @@ class Handler(BaseCache):
             )
             raise AccessException(err)
         except KeyError:
-            self.logger.info("No value found in cache", extra={"pk": pk, "sk": sk})
+            self.logger.debug("No value found in cache", extra={"pk": pk, "sk": sk})
             raise NotFoundException()
 
         return str(pointer)

--- a/grove/caches/local_file.py
+++ b/grove/caches/local_file.py
@@ -83,7 +83,7 @@ class Handler(BaseCache):
             raise AccessException(f"Unable to read cache entry from {path}. {err}")
 
         if value is None:
-            self.logger.info("No value found in cache", extra={"pk": pk, "sk": sk})
+            self.logger.debug("No value found in cache", extra={"pk": pk, "sk": sk})
             raise NotFoundException("No value found in cache")
 
         return value

--- a/grove/caches/local_memory.py
+++ b/grove/caches/local_memory.py
@@ -30,7 +30,7 @@ class Handler(BaseCache):
         value = self._data.get(pk, {}).get(sk, None)
 
         if value is None:
-            self.logger.info("No value found in cache", extra={"pk": pk, "sk": sk})
+            self.logger.debug("No value found in cache", extra={"pk": pk, "sk": sk})
             raise NotFoundException("No value found in cache")
 
         return value

--- a/grove/entrypoints/local_daemon.py
+++ b/grove/entrypoints/local_daemon.py
@@ -170,6 +170,7 @@ def entrypoint():
                             "connector": run.configuration.connector,
                         },
                     )
+                    run.future = None
 
                 logger.info(
                     "Connector has exited.",

--- a/grove/entrypoints/local_daemon.py
+++ b/grove/entrypoints/local_daemon.py
@@ -138,7 +138,7 @@ def entrypoint():
                         continue
 
                     # Otherwise, schedule it and track the run. If the connector isn't
-                    # due to run, if it has run more recently inz another location, then
+                    # due to run, if it has run more recently in another location, then
                     # the local 'last' time will be replaced with the cached value when
                     # the future returns.
                     future = pool.submit(base.dispatch, configuration, context)

--- a/grove/entrypoints/local_daemon.py
+++ b/grove/entrypoints/local_daemon.py
@@ -138,7 +138,7 @@ def entrypoint():
                         continue
 
                     # Otherwise, schedule it and track the run. If the connector isn't
-                    # due to run, if it has run more recently in another location, then
+                    # due to run, if it has run more recently inz another location, then
                     # the local 'last' time will be replaced with the cached value when
                     # the future returns.
                     future = pool.submit(base.dispatch, configuration, context)
@@ -158,7 +158,10 @@ def entrypoint():
 
                     run.last = run.future.result()
                     run.future = None
-                except GroveException as err:
+                except Exception as err:
+                    # We catch as wide as exception as possible here to try and avoid
+                    # an unhandled error in a connector from taking down the main event
+                    # loop.
                     logger.error(
                         "Connector exited abnormally.",
                         extra={


### PR DESCRIPTION
## Overview

This pull-request genericises the exception handler in the `groved` event loop in order to ensure unhandled exceptions don't bubble up and and kill the main event loop.

This also moves a number of lo messages to debug to avoid confusion when reviewing logs.