### PR TITLE
🐛 Fix up retry logic on connector failures, various other bug fixes.

### DIFF
--- a/grove/__about__.py
+++ b/grove/__about__.py
@@ -1,6 +1,6 @@
 """Grove metadata."""
 
-__version__ = "2.1.1"
+__version__ = "2.2.0"
 __title__ = "grove"
 __license__ = "Mozilla Public License 2.0"
 __copyright__ = "Copyright 2025 HashiCorp, Inc."

--- a/grove/entrypoints/base.py
+++ b/grove/entrypoints/base.py
@@ -21,7 +21,7 @@ from grove.constants import (
     PLUGIN_GROUP_CONNECTOR,
     PLUGIN_GROUP_SECRET,
 )
-from grove.exceptions import GroveException
+from grove.exceptions import ConcurrencyException, GroveException
 from grove.helpers import plugin
 from grove.logging import GroveFormatter
 from grove.models import ConnectorConfig
@@ -131,6 +131,10 @@ def entrypoint(context: Dict[str, Any]):
             # logged out.
             try:
                 _ = future.result()
+            except ConcurrencyException:
+                # We don't consider concurrency to be abnormal - as it may indicate
+                # another worker has scheduled the connector before us.
+                pass
             except GroveException as err:
                 logger.error(
                     "Connector exited abnormally.",

--- a/grove/helpers/parsing.py
+++ b/grove/helpers/parsing.py
@@ -45,7 +45,7 @@ def quick_copy(value: Any):
 
     :return: The deep copy of the input value.
     """
-    return json.loads(json.dumps(value))
+    return json.loads(json.dumps(value, default=str))
 
 
 def quote_aware_split(value: str, delimiter=".") -> List[str]:

--- a/grove/outputs/local_stdout.py
+++ b/grove/outputs/local_stdout.py
@@ -76,7 +76,7 @@ class Handler(BaseOutput):
             # We don't want to silently drop and lose single records, so drop the entire
             # batch if there is bad data (which will trigger a retry next run).
             try:
-                candidate.append(json.dumps(entry, separators=(",", ":")))
+                candidate.append(json.dumps(entry, separators=(",", ":"), default=str))
             except TypeError as err:
                 message = f"Unable to serialize to JSON: {err}"
                 raise DataFormatException(message)

--- a/grove/outputs/remote_http.py
+++ b/grove/outputs/remote_http.py
@@ -164,7 +164,7 @@ class Handler(BaseOutput):
             # We don't want to silently drop and lose single records, so drop the entire
             # batch if there is bad data (which will trigger a retry next run).
             try:
-                candidate.append(json.dumps(entry, separators=(",", ":")))
+                candidate.append(json.dumps(entry, separators=(",", ":"), default=str))
             except TypeError as err:
                 raise DataFormatException(f"Unable to serialize to JSON: {err}")
 

--- a/grove/processors/extract_paths.py
+++ b/grove/processors/extract_paths.py
@@ -70,7 +70,7 @@ class Handler(BaseProcessor):
             result = parsing.update_path(
                 result,
                 parsing.quote_aware_split(self.configuration.raw),
-                json.dumps(entry, separators=(",", ":")),
+                json.dumps(entry, separators=(",", ":"), default=str),
             )
 
         for field in self.configuration.fields:

--- a/tests/fixtures/grove/reverse_chronological/003.json
+++ b/tests/fixtures/grove/reverse_chronological/003.json
@@ -2,10 +2,6 @@
     "logs": [
         {
             "timestamp": "7",
-            "event": "Example H"
-        },
-        {
-            "timestamp": "7",
             "event": "Example G"
         }
     ],


### PR DESCRIPTION
## Overview

This pull-request attempts to resolve #80 and #81, including:

* Fixes silly bug related to use of seconds vs total_seconds in dispatch.
* Fixes default serialisation prior to adding common serialiser (#85).
* Makes sure deduplication hash cache doesn't grow infinitely on massive collections.
* Ensures pointer deduplication operates the same way between chronological and reverse chronological ordering.
