### PR TITLE
Feature/1password eu endpoint support

### DIFF
--- a/grove/connectors/onepassword/api.py
+++ b/grove/connectors/onepassword/api.py
@@ -12,26 +12,28 @@ import requests
 from grove.exceptions import RateLimitException, RequestFailedException
 from grove.types import AuditLogEntries, HTTPResponse
 
-API_HOSTNAME = "events.1password.com"
+API_HOSTNAME = "events.{domain}"  # Domain will be inserted from config
+API_DEFAULT_DOMAIN = "1password.com"  # Default to US endpoint
 API_PAGE_SIZE = 1000
 
 
 class Client:
     def __init__(
         self,
-        hostname: Optional[str] = API_HOSTNAME,
+        domain: Optional[str] = API_DEFAULT_DOMAIN,
         token: Optional[str] = None,
         retry: Optional[bool] = True,
     ):
         """Setup a new 1Password audit log client.
 
-        :param hostname: Hostname of the 1Password API to interact with.
+        :param domain: Domain suffix for the 1Password API ('1password.com' for US, '1password.eu' for EU).
+                       Defaults to '1password.com' (US endpoint).
         :param token: 1Password token to authenticate with.
         :param retry: Automatically retry if recoverable errors are encountered, such as
             rate-limiting.
         """
         self.retry = retry
-        self.hostname = hostname
+        self.hostname = API_HOSTNAME.format(domain=domain or API_DEFAULT_DOMAIN)
         self.logger = logging.getLogger(__name__)
         self.headers = {
             "Authorization": f"Bearer {token}",

--- a/grove/connectors/onepassword/common.py
+++ b/grove/connectors/onepassword/common.py
@@ -12,22 +12,31 @@ from grove.exceptions import ConfigurationException
 
 
 API_DEFAULT_DOMAIN = "1password.com"  # Default to US endpoint
+VALID_DOMAINS = {
+    "ent.1password.com",  # Enterprise US
+    "1password.com",      # Business US
+    "1password.eu",       # Business EU
+    "1password.ca"        # Business Canada
+}
 
 class OnePasswordConnector(BaseConnector):
-    """Defines common fields used across all 1Password connector types.
-
-    This has been done to reduce the amount of boilerplate and duplication across the
-    different 1Password connectors in Grove.
-    """
+    """Defines common fields used across all 1Password connector types."""
 
     @property
     def domain(self) -> str:
-        """Fetches the domain from the configuration.
-
-        :return: The "domain" portion of the connector's configuration.
+        """Fetches and validates the domain from the configuration.
+        
+        :return: The validated domain from configuration or default
+        :raises ConfigurationException: If configured domain is not valid
         """
         try:
-            return self.configuration.domain
-
+            domain = self.configuration.domain
+            if domain not in VALID_DOMAINS:
+                raise ConfigurationException(
+                    f"Invalid 1Password domain '{domain}'. "
+                    f"Must be one of: {', '.join(VALID_DOMAINS)}"
+                )
+            return domain
+            
         except AttributeError:
             return API_DEFAULT_DOMAIN

--- a/grove/connectors/onepassword/common.py
+++ b/grove/connectors/onepassword/common.py
@@ -11,6 +11,8 @@ from grove.connectors import BaseConnector
 from grove.exceptions import ConfigurationException
 
 
+API_DEFAULT_DOMAIN = "1password.com"  # Default to US endpoint
+
 class OnePasswordConnector(BaseConnector):
     """Defines common fields used across all 1Password connector types.
 
@@ -28,4 +30,4 @@ class OnePasswordConnector(BaseConnector):
             return self.configuration.domain
 
         except AttributeError:
-            return API_HOSTNAME
+            return API_DEFAULT_DOMAIN

--- a/grove/connectors/onepassword/common.py
+++ b/grove/connectors/onepassword/common.py
@@ -1,0 +1,31 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+"""1Password connector for Grove."""
+
+from typing import Optional
+
+from cryptography.hazmat.primitives import serialization
+
+from grove.connectors import BaseConnector
+from grove.exceptions import ConfigurationException
+
+
+class OnePasswordConnector(BaseConnector):
+    """Defines common fields used across all 1Password connector types.
+
+    This has been done to reduce the amount of boilerplate and duplication across the
+    different 1Password connectors in Grove.
+    """
+
+    @property
+    def domain(self) -> str:
+        """Fetches the domain from the configuration.
+
+        :return: The "domain" portion of the connector's configuration.
+        """
+        try:
+            return self.configuration.domain
+
+        except AttributeError:
+            return API_HOSTNAME

--- a/grove/connectors/onepassword/events_audit.py
+++ b/grove/connectors/onepassword/events_audit.py
@@ -20,7 +20,7 @@ class Connector(OnePasswordConnector):
         This will first check whether there are any pointers cached to indicate previous
         collections. If not, the last week of data will be collected.
         """
-        client = Client(token=self.key, hostname=self.domain)
+        client = Client(token=self.key, domain=self.domain)
 
         # self.pointer could start out as either a cursor or ISO timestamp depending on if this
         # is an upgrade. That said, once we reach here, cursor will always be used as the

--- a/grove/connectors/onepassword/events_audit.py
+++ b/grove/connectors/onepassword/events_audit.py
@@ -3,13 +3,13 @@
 
 """1Password Audit event log connector for Grove."""
 
-from grove.connectors import BaseConnector
+from grove.connectors.onepassword.common import OnePasswordConnector
 from grove.connectors.onepassword.api import Client
 from grove.connectors.onepassword.util import get_pointer_values
 from grove.constants import CHRONOLOGICAL
 
 
-class Connector(BaseConnector):
+class Connector(OnePasswordConnector):
     CONNECTOR = "onepassword_events_audit"
     POINTER_PATH = "cursor"
     LOG_ORDER = CHRONOLOGICAL
@@ -20,7 +20,7 @@ class Connector(BaseConnector):
         This will first check whether there are any pointers cached to indicate previous
         collections. If not, the last week of data will be collected.
         """
-        client = Client(token=self.key)
+        client = Client(token=self.key, hostname=self.domain)
 
         # self.pointer could start out as either a cursor or ISO timestamp depending on if this
         # is an upgrade. That said, once we reach here, cursor will always be used as the

--- a/grove/connectors/onepassword/events_itemusages.py
+++ b/grove/connectors/onepassword/events_itemusages.py
@@ -19,7 +19,7 @@ class Connector(OnePasswordConnector):
         This will first check whether there are any pointers cached to indicate previous
         collections. If not, the last week of data will be collected.
         """
-        client = Client(token=self.key, hostname=self.domain)
+        client = Client(token=self.key, domain=self.domain)
 
         # self.pointer could start out as either a cursor or ISO timestamp depending on if this
         # is an upgrade. That said, once we reach here, cursor will always be used as the

--- a/grove/connectors/onepassword/events_itemusages.py
+++ b/grove/connectors/onepassword/events_itemusages.py
@@ -3,12 +3,12 @@
 
 """1Password ItemUsage event log connector for Grove."""
 from grove.connectors.onepassword.api import Client
-from grove.connectors import BaseConnector
+from grove.connectors.onepassword.common import OnePasswordConnector
 from grove.constants import CHRONOLOGICAL
 from grove.connectors.onepassword.util import get_pointer_values
 
 
-class Connector(BaseConnector):
+class Connector(OnePasswordConnector):
     CONNECTOR = "onepassword_events_itemusages"
     POINTER_PATH = "cursor"
     LOG_ORDER = CHRONOLOGICAL
@@ -19,7 +19,7 @@ class Connector(BaseConnector):
         This will first check whether there are any pointers cached to indicate previous
         collections. If not, the last week of data will be collected.
         """
-        client = Client(token=self.key)
+        client = Client(token=self.key, hostname=self.domain)
 
         # self.pointer could start out as either a cursor or ISO timestamp depending on if this
         # is an upgrade. That said, once we reach here, cursor will always be used as the

--- a/grove/connectors/onepassword/events_signinattempts.py
+++ b/grove/connectors/onepassword/events_signinattempts.py
@@ -20,7 +20,7 @@ class Connector(OnePasswordConnector):
         This will first check whether there are any pointers cached to indicate previous
         collections. If not, the last week of data will be collected.
         """
-        client = Client(token=self.key, hostname=self.domain)
+        client = Client(token=self.key, domain=self.domain)
 
         # self.pointer could start out as either a cursor or ISO timestamp depending on if this
         # is an upgrade. That said, once we reach here, cursor will always be used as the

--- a/grove/connectors/onepassword/events_signinattempts.py
+++ b/grove/connectors/onepassword/events_signinattempts.py
@@ -4,12 +4,12 @@
 """1Password Signin Attempt event log connector for Grove."""
 
 from grove.connectors.onepassword.api import Client
-from grove.connectors import BaseConnector
+from grove.connectors.onepassword.common import OnePasswordConnector
 from grove.constants import CHRONOLOGICAL
 from grove.connectors.onepassword.util import get_pointer_values
 
 
-class Connector(BaseConnector):
+class Connector(OnePasswordConnector):
     CONNECTOR = "onepassword_events_signinattempts"
     POINTER_PATH = "cursor"
     LOG_ORDER = CHRONOLOGICAL
@@ -20,7 +20,7 @@ class Connector(BaseConnector):
         This will first check whether there are any pointers cached to indicate previous
         collections. If not, the last week of data will be collected.
         """
-        client = Client(token=self.key)
+        client = Client(token=self.key, hostname=self.domain)
 
         # self.pointer could start out as either a cursor or ISO timestamp depending on if this
         # is an upgrade. That said, once we reach here, cursor will always be used as the

--- a/templates/configuration/1password/events_audit.json
+++ b/templates/configuration/1password/events_audit.json
@@ -1,7 +1,7 @@
 {
     "key": "BEARER_TOKEN_HERE",
     "identity": "ORGANIZATION_NAME_HERE",
-    "domain": "events.1password.com",
+    "domain": "1password.com",
     "name": "1password-events-audit",
     "connector": "onepassword_events_audit"
 }

--- a/templates/configuration/1password/events_audit.json
+++ b/templates/configuration/1password/events_audit.json
@@ -1,7 +1,7 @@
 {
     "key": "BEARER_TOKEN_HERE",
     "identity": "ORGANIZATION_NAME_HERE",
-    "domain": "1password.com",
+    "domain": "events.1password.com",
     "name": "1password-events-audit",
     "connector": "onepassword_events_audit"
 }

--- a/templates/configuration/1password/events_audit.json
+++ b/templates/configuration/1password/events_audit.json
@@ -1,6 +1,7 @@
 {
     "key": "BEARER_TOKEN_HERE",
     "identity": "ORGANIZATION_NAME_HERE",
+    "domain": "1password.com",
     "name": "1password-events-audit",
     "connector": "onepassword_events_audit"
 }

--- a/templates/configuration/1password/events_itemusages.json
+++ b/templates/configuration/1password/events_itemusages.json
@@ -1,6 +1,7 @@
 {
     "key": "BEARER_TOKEN_HERE",
     "identity": "ORGANIZATION_NAME_HERE",
+    "domain": "1password.com",
     "name": "1password-events-itemusages-example",
     "connector": "onepassword_events_itemusages"
 }

--- a/templates/configuration/1password/events_itemusages.json
+++ b/templates/configuration/1password/events_itemusages.json
@@ -1,7 +1,7 @@
 {
     "key": "BEARER_TOKEN_HERE",
     "identity": "ORGANIZATION_NAME_HERE",
-    "domain": "1password.com",
+    "domain": "events.1password.com",
     "name": "1password-events-itemusages-example",
     "connector": "onepassword_events_itemusages"
 }

--- a/templates/configuration/1password/events_itemusages.json
+++ b/templates/configuration/1password/events_itemusages.json
@@ -1,7 +1,7 @@
 {
     "key": "BEARER_TOKEN_HERE",
     "identity": "ORGANIZATION_NAME_HERE",
-    "domain": "events.1password.com",
+    "domain": "1password.com",
     "name": "1password-events-itemusages-example",
     "connector": "onepassword_events_itemusages"
 }

--- a/templates/configuration/1password/events_signinattempts.json
+++ b/templates/configuration/1password/events_signinattempts.json
@@ -1,6 +1,7 @@
 {
     "key": "BEARER_TOKEN_HERE",
     "identity": "ORGANIZATION_NAME_HERE",
+    "domain": "1password.com",
     "name": "1password-events-signinattempts-example",
     "connector": "onepassword_events_signinattempts"
 }

--- a/templates/configuration/1password/events_signinattempts.json
+++ b/templates/configuration/1password/events_signinattempts.json
@@ -1,7 +1,7 @@
 {
     "key": "BEARER_TOKEN_HERE",
     "identity": "ORGANIZATION_NAME_HERE",
-    "domain": "1password.com",
+    "domain": "events.1password.com",
     "name": "1password-events-signinattempts-example",
     "connector": "onepassword_events_signinattempts"
 }

--- a/templates/configuration/1password/events_signinattempts.json
+++ b/templates/configuration/1password/events_signinattempts.json
@@ -1,7 +1,7 @@
 {
     "key": "BEARER_TOKEN_HERE",
     "identity": "ORGANIZATION_NAME_HERE",
-    "domain": "events.1password.com",
+    "domain": "1password.com",
     "name": "1password-events-signinattempts-example",
     "connector": "onepassword_events_signinattempts"
 }


### PR DESCRIPTION
Tested locally with passing a test config in: templates/deployment/local-quick-start/connectors/1password.json

Tests:
1. Test for default domain - when a domain is not passed in the config, it correctly defaults to 1password.com
2. Test for a valid domain passed in config - passed 1password.eu in config and saw the logs on the console for all 3 event types
3. Test for invalid domain - passed a bogus domain to check if the validation works properly