### PR TITLE
add utc timezone to start_date

### DIFF
--- a/grove/connectors/gsuite/usage.py
+++ b/grove/connectors/gsuite/usage.py
@@ -110,7 +110,7 @@ class Connector(BaseConnector):
         now = datetime.now(tz=timezone.utc)
 
         try:
-            start_date = datetime.strptime(self.pointer, "%Y-%m-%d")
+            start_date = datetime.strptime(self.pointer, "%Y-%m-%d").replace(tzinfo=timezone.utc)
         except NotFoundException:
             start_date = now - timedelta(days=7)
             self.pointer = start_date.strftime("%Y-%m-%d")


### PR DESCRIPTION
# Gsuite Usage Bugfix
Recent commit [273ea68](https://github.com/hashicorp-forge/grove/commit/273ea686c6df3bab9c76637ce72414c94b86eee4) introduced Google Workspaces (GSuite) connector for Entity, User, and Customer Usage reports. 

In feedback, we decided to enforce setting a timezone (UTC) to be used in calculating and paginating using pointer (date). However, we failed to note that the current logic doesn't instantiate a `start_date` using UTC time on the first run. This will lead to `TypeError: can't compare offset-naive and offset-aware datetimes` when attempting to compare offset-naive pointer dates with the offset-aware pointer.

This bugfix adds UTC time to the `start_date`, which allows for pagination.
