### PR TITLE
Add AWS session regeneration on expiry.

### DIFF
--- a/grove/caches/__init__.py
+++ b/grove/caches/__init__.py
@@ -8,6 +8,13 @@ from typing import Optional
 
 
 class BaseCache(abc.ABC):
+    def setup(self):
+        """Implements logic to setup any required clients, sockets, or connections.
+
+        If not required for the given cache handler, this may be a no-op.
+        """
+        pass
+
     @abc.abstractmethod
     def get(self, pk: str, sk: str) -> str:
         """Gets the value for the given key from the cache.

--- a/grove/connectors/__init__.py
+++ b/grove/connectors/__init__.py
@@ -93,6 +93,8 @@ class BaseConnector:
             os.environ.get(ENV_GROVE_CACHE_HANDLER, DEFAULT_CACHE_HANDLER),
             PLUGIN_GROUP_CACHE,
         )
+        self._cache.setup()
+
         self._output = plugin.load_handler(
             os.environ.get(ENV_GROVE_OUTPUT_HANDLER, DEFAULT_OUTPUT_HANDLER),
             PLUGIN_GROUP_OUTPUT,


### PR DESCRIPTION
## Overview

Currently, when configured with AWS based backends for caching or output, using STS tokens, sessions may expire during collection - when log collections are occurring.

This change ensures that sessions are attempted to be regenerated if and when this occurs, and adds an optional and backwards compatible hook to the base Cache class to match the implementation of output handlers.