### PR TITLE
refactor bigquery connector and add tests

### DIFF
--- a/grove/connectors/google/utils.py
+++ b/grove/connectors/google/utils.py
@@ -1,0 +1,60 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+"""Google BigQuery utility functions for Grove."""
+
+from datetime import datetime, timezone
+
+
+def as_bigquery_timestamp_microseconds(epoch_usec) -> str:
+    """
+    Converts epoch time in microseconds to a BigQuery-compatible timestamp string.
+
+    :param epoch_usec: The epoch time in microseconds (int, str, or float).
+    :return: A BigQuery TIMESTAMP formatted date string (YYYY-MM-DD HH:MM:SS+00).
+    """
+    # Convert to int if it's a string
+    if isinstance(epoch_usec, str):
+        epoch_usec = int(epoch_usec)
+    
+    # Convert microseconds to seconds
+    timestamp_seconds = epoch_usec / 1_000_000.0
+    
+    dt = datetime.fromtimestamp(timestamp_seconds, tz=timezone.utc)
+    # BigQuery expects "+00" not "+0000" or "+00:00"
+    return dt.strftime("%Y-%m-%d %H:%M:%S+00")
+
+
+def as_bigquery_timestamp_seconds(epoch_sec) -> str:
+    """
+    Converts epoch time in seconds to a BigQuery-compatible timestamp string.
+
+    :param epoch_sec: The epoch time in seconds (int, str, or float).
+    :return: A BigQuery TIMESTAMP formatted date string (YYYY-MM-DD HH:MM:SS+00).
+    """
+    # Convert to float if it's a string
+    if isinstance(epoch_sec, str):
+        epoch_sec = float(epoch_sec)
+    
+    dt = datetime.fromtimestamp(epoch_sec, tz=timezone.utc)
+    # BigQuery expects "+00" not "+0000" or "+00:00"
+    return dt.strftime("%Y-%m-%d %H:%M:%S+00")
+
+
+def as_bigquery_timestamp_milliseconds(epoch_msec) -> str:
+    """
+    Converts epoch time in milliseconds to a BigQuery-compatible timestamp string.
+
+    :param epoch_msec: The epoch time in milliseconds (int, str, or float).
+    :return: A BigQuery TIMESTAMP formatted date string (YYYY-MM-DD HH:MM:SS+00).
+    """
+    # Convert to int if it's a string
+    if isinstance(epoch_msec, str):
+        epoch_msec = int(epoch_msec)
+    
+    # Convert milliseconds to seconds
+    timestamp_seconds = epoch_msec / 1_000.0
+    
+    dt = datetime.fromtimestamp(timestamp_seconds, tz=timezone.utc)
+    # BigQuery expects "+00" not "+0000" or "+00:00"
+    return dt.strftime("%Y-%m-%d %H:%M:%S+00") 

--- a/tests/test_connectors_google_bigquery_query.py
+++ b/tests/test_connectors_google_bigquery_query.py
@@ -1,0 +1,103 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+"""Implements unit tests for the Google BigQuery Query connector."""
+
+import json
+import os
+import unittest
+from unittest.mock import Mock, patch
+
+from grove.connectors.google.bigquery_query import Connector
+from grove.models import ConnectorConfig
+from tests import mocks
+
+
+class GoogleBigQueryQueryTestCase(unittest.TestCase):
+    """Implements unit tests for the Google BigQuery Query connector."""
+
+    @patch("grove.helpers.plugin.load_handler", mocks.load_handler)
+    def setUp(self):
+        """Ensure the application is setup for testing."""
+        self.dir = os.path.dirname(os.path.abspath(__file__))
+        
+        self.connector = Connector(
+            config=ConnectorConfig(
+                identity="test-project",
+                key="{}",  # Empty JSON, will be mocked
+                name="test-bigquery",
+                connector="google_bigquery_query",
+                project_id="test-project",
+                dataset_name="test_dataset",
+                table_name="test_table",
+                columns=["timestamp_usec", "message", "user_id"],
+                pointer_path="timestamp_usec",
+            ),
+            context={
+                "runtime": "test_harness",
+                "runtime_id": "NA",
+            },
+        )
+
+    @patch('grove.connectors.google.bigquery_query.bigquery.Client')
+    @patch.object(Connector, 'get_credentials')
+    def test_collect_no_pagination(self, mock_get_creds, mock_bigquery_client):
+        """Ensure collection without pagination works as expected."""
+        # Mock credentials
+        mock_get_creds.return_value = Mock()
+        
+        # Mock BigQuery client and query results
+        mock_client = Mock()
+        mock_bigquery_client.return_value = mock_client
+        
+        mock_query_job = Mock()
+        mock_client.query.return_value = mock_query_job
+        
+        # Mock query results - less than 1000 rows (no pagination needed)
+        mock_rows = [
+            {"timestamp_usec": 1738500089504000, "message": "Test log 1", "user_id": "user1"},
+            {"timestamp_usec": 1738500089505000, "message": "Test log 2", "user_id": "user2"},
+        ]
+        mock_query_job.result.return_value = mock_rows
+        
+        # Set initial pointer
+        self.connector._pointer = "1738500089504000"
+        
+        # Run collection
+        self.connector.run()
+        
+        # Verify results
+        self.assertEqual(self.connector._saved["logs"], 2)
+        # Note: pointer won't be updated since we're mocking the save method
+
+    @patch('grove.connectors.google.bigquery_query.bigquery.Client')
+    @patch.object(Connector, 'get_credentials')  
+    def test_collect_with_pagination(self, mock_get_creds, mock_bigquery_client):
+        """Ensure collection with pagination works as expected."""
+        # Mock credentials
+        mock_get_creds.return_value = Mock()
+        
+        # Mock BigQuery client and query results
+        mock_client = Mock()
+        mock_bigquery_client.return_value = mock_client
+        
+        mock_query_job = Mock()
+        mock_client.query.return_value = mock_query_job
+        
+        # First call returns 1000 rows (triggers pagination)
+        # Second call returns 500 rows (ends pagination)
+        mock_rows_1000 = [{"timestamp_usec": i, "message": f"Log {i}"} for i in range(1000)]
+        mock_rows_500 = [{"timestamp_usec": i + 1000, "message": f"Log {i + 1000}"} for i in range(500)]
+        
+        mock_query_job.result.side_effect = [mock_rows_1000, mock_rows_500]
+        
+        # Set initial pointer
+        self.connector._pointer = "1000000000000000"
+        
+        # Run collection
+        self.connector.run()
+        
+        # Verify pagination occurred (query called twice)
+        self.assertEqual(mock_client.query.call_count, 2)
+        # Total logs saved: 1000 + 500 = 1500
+        self.assertEqual(self.connector._saved["logs"], 1500)

--- a/tests/test_connectors_google_utils.py
+++ b/tests/test_connectors_google_utils.py
@@ -1,0 +1,120 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+"""Implements unit tests for the Google BigQuery utility functions."""
+
+import unittest
+from datetime import datetime, timezone
+
+from grove.connectors.google.utils import (
+    as_bigquery_timestamp_microseconds,
+    as_bigquery_timestamp_seconds,
+    as_bigquery_timestamp_milliseconds,
+)
+
+
+class GoogleBigQueryUtilsTestCase(unittest.TestCase):
+    """Implements unit tests for the Google BigQuery utility functions."""
+
+    def test_as_bigquery_timestamp_microseconds(self):
+        """Ensure microsecond timestamp conversion works as expected."""
+        # Test with integer microseconds (Gmail logs format)
+        us_timestamp = 1738500089504000  # 2025-02-02 12:41:29.504 UTC
+        result = as_bigquery_timestamp_microseconds(us_timestamp)
+        self.assertEqual(result, "2025-02-02 12:41:29+00")
+
+        # Test with string input
+        us_timestamp_str = "1738500089504000"
+        result = as_bigquery_timestamp_microseconds(us_timestamp_str)
+        self.assertEqual(result, "2025-02-02 12:41:29+00")
+
+        # Test with float input
+        us_timestamp_float = 1738500089504000.0
+        result = as_bigquery_timestamp_microseconds(us_timestamp_float)
+        self.assertEqual(result, "2025-02-02 12:41:29+00")
+
+    def test_as_bigquery_timestamp_seconds(self):
+        """Ensure second timestamp conversion works as expected."""
+        # Test with integer seconds (Unix timestamp)
+        sec_timestamp = 1738500089  # 2025-02-02 12:41:29 UTC
+        result = as_bigquery_timestamp_seconds(sec_timestamp)
+        self.assertEqual(result, "2025-02-02 12:41:29+00")
+
+        # Test with string input
+        sec_timestamp_str = "1738500089"
+        result = as_bigquery_timestamp_seconds(sec_timestamp_str)
+        self.assertEqual(result, "2025-02-02 12:41:29+00")
+
+        # Test with float input (for fractional seconds)
+        sec_timestamp_float = 1738500089.5
+        result = as_bigquery_timestamp_seconds(sec_timestamp_float)
+        self.assertEqual(result, "2025-02-02 12:41:29+00")
+
+    def test_as_bigquery_timestamp_milliseconds(self):
+        """Ensure millisecond timestamp conversion works as expected."""
+        # Test with integer milliseconds (JavaScript Date.now() format)
+        ms_timestamp = 1738500089504  # 2025-02-02 12:41:29.504 UTC
+        result = as_bigquery_timestamp_milliseconds(ms_timestamp)
+        self.assertEqual(result, "2025-02-02 12:41:29+00")
+
+        # Test with string input
+        ms_timestamp_str = "1738500089504"
+        result = as_bigquery_timestamp_milliseconds(ms_timestamp_str)
+        self.assertEqual(result, "2025-02-02 12:41:29+00")
+
+        # Test with float input
+        ms_timestamp_float = 1738500089504.0
+        result = as_bigquery_timestamp_milliseconds(ms_timestamp_float)
+        self.assertEqual(result, "2025-02-02 12:41:29+00")
+
+    def test_timezone_handling(self):
+        """Ensure all functions handle timezone correctly."""
+        # All functions should produce UTC timestamps with +00 suffix
+        us_timestamp = 1738500089504000
+        sec_timestamp = 1738500089
+        ms_timestamp = 1738500089504
+
+        us_result = as_bigquery_timestamp_microseconds(us_timestamp)
+        sec_result = as_bigquery_timestamp_seconds(sec_timestamp)
+        ms_result = as_bigquery_timestamp_milliseconds(ms_timestamp)
+
+        # All should end with +00 (UTC)
+        self.assertTrue(us_result.endswith("+00"))
+        self.assertTrue(sec_result.endswith("+00"))
+        self.assertTrue(ms_result.endswith("+00"))
+
+        # Microseconds and milliseconds should produce the same result for this timestamp
+        self.assertEqual(us_result, ms_result)
+
+    def test_format_consistency(self):
+        """Ensure all functions produce consistent BigQuery timestamp format."""
+        us_timestamp = 1738500089504000
+        sec_timestamp = 1738500089
+        ms_timestamp = 1738500089504
+
+        us_result = as_bigquery_timestamp_microseconds(us_timestamp)
+        sec_result = as_bigquery_timestamp_seconds(sec_timestamp)
+        ms_result = as_bigquery_timestamp_milliseconds(ms_timestamp)
+
+        # All should match the expected format: YYYY-MM-DD HH:MM:SS+00
+        import re
+        pattern = r'^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\+00$'
+        
+        self.assertTrue(re.match(pattern, us_result))
+        self.assertTrue(re.match(pattern, sec_result))
+        self.assertTrue(re.match(pattern, ms_result))
+
+    def test_epoch_edge_cases(self):
+        """Test edge cases around epoch time."""
+        # Test epoch start (1970-01-01 00:00:00 UTC)
+        epoch_us = 0
+        epoch_sec = 0
+        epoch_ms = 0
+
+        us_result = as_bigquery_timestamp_microseconds(epoch_us)
+        sec_result = as_bigquery_timestamp_seconds(epoch_sec)
+        ms_result = as_bigquery_timestamp_milliseconds(epoch_ms)
+
+        self.assertEqual(us_result, "1970-01-01 00:00:00+00")
+        self.assertEqual(sec_result, "1970-01-01 00:00:00+00")
+        self.assertEqual(ms_result, "1970-01-01 00:00:00+00") 


### PR DESCRIPTION
- Adds another bugfix to the google bigquery connector
  - We were using this to retrieve [Gmail logs stored in bigquery ](https://support.google.com/a/answer/12384955?hl=en&src=supportwidget0&authuser=0) and, although the connector worked for some time and would retrieve and paginate logs, after some time we would see errors that the date for the pointer became out of range
  - Looking back at our logic for declaring and updating the pointer, we realized that the `event_info.timestamp_usec` field is actually in microseconds - *not* milliseconds
  - Rather than make one small fix to update this logic, we refactored the connector to use a microseconds conversion helper function, while keeping the ability to use a milliseconds function and also added a seconds function. This modular approach allows other users to develop new connectors or scripts to adapt to the structure of their own BigQuery tables
- Added test cases for the above to ensure that we don't repeat this error

I apologize again for missing this! Expect all future contributions to include test cases.