### PR TITLE
bugfix: add max_batches logic

### DIFF
--- a/grove/connectors/google/bigquery_query.py
+++ b/grove/connectors/google/bigquery_query.py
@@ -33,6 +33,7 @@ class Connector(BaseConnector):
             dataset_name = self.configuration.dataset_name
             table_name = self.configuration.table_name
             columns = self.configuration.columns
+            max_batches = self.configuration.max_batches
             self.POINTER_PATH = self.configuration.pointer_path
 
             self.logger.debug("Configuration parameters:")
@@ -44,6 +45,14 @@ class Connector(BaseConnector):
             if not self.POINTER_PATH:
                 raise ConfigurationException(
                     "POINTER_PATH is not set in the configuration."
+                )
+            
+            if max_batches is None:
+                max_batches = 3
+
+            if not isinstance(max_batches, int) or max_batches <= 0:
+                raise ConfigurationException(
+                    "max_batches must be a positive integer."
                 )
 
             for value in [project_id, dataset_name, table_name]:
@@ -81,6 +90,10 @@ class Connector(BaseConnector):
 
         str_pointer = as_bigquery_timestamp_microseconds(pointer_epoch_usec)
 
+        # Configuration for batching
+        all_rows = []
+        batch_count = 0
+
         while True:
             self.logger.debug(f"Pointer for query: {str_pointer} ({type(str_pointer)})")
 
@@ -105,10 +118,15 @@ class Connector(BaseConnector):
                     self.logger.info("No more logs found.")
                     break
 
-                self.logger.info(f"Collected {len(rows)} logs.")
-                self.save(rows)
+                self.logger.info(f"Collected {len(rows)} logs in batch {batch_count + 1}.")
+                all_rows.extend(rows)
+                batch_count += 1
 
-                if len(rows) < 1000:
+                # Save and break if we've collected enough batches or reached the end
+                if batch_count >= max_batches or len(rows) < 1000:
+                    if all_rows:
+                        self.logger.info(f"Saving {len(all_rows)} total logs from {batch_count} batches.")
+                        self.save(all_rows)
                     break
 
             except Exception as err:

--- a/grove/connectors/google/bigquery_query.py
+++ b/grove/connectors/google/bigquery_query.py
@@ -125,7 +125,7 @@ class Connector(BaseConnector):
                 # Save and break if we've collected enough batches or reached the end
                 if batch_count >= max_batches or len(rows) < 1000:
                     if all_rows:
-                        self.logger.info(f"Saving {len(all_rows)} total logs from {batch_count} batches.")
+                        self.logger.debug(f"Saving {len(all_rows)} total logs from {batch_count} batches.")
                         self.save(all_rows)
                     break
 

--- a/tests/test_connectors_google_bigquery_query.py
+++ b/tests/test_connectors_google_bigquery_query.py
@@ -32,6 +32,7 @@ class GoogleBigQueryQueryTestCase(unittest.TestCase):
                 table_name="test_table",
                 columns=["timestamp_usec", "message", "user_id"],
                 pointer_path="timestamp_usec",
+                max_batches=1
             ),
             context={
                 "runtime": "test_harness",
@@ -93,6 +94,9 @@ class GoogleBigQueryQueryTestCase(unittest.TestCase):
         
         # Set initial pointer
         self.connector._pointer = "1000000000000000"
+        
+        # Set max_batches to 2 for this test
+        self.connector.configuration.max_batches = 2
         
         # Run collection
         self.connector.run()


### PR DESCRIPTION
This PR adds `max_batches` logic to Google Bigquery connector to allow the connector to save a batch of logs (default `3`) and exit, allowing other connectors to run.

This was after we noticed in our deployment that the connector would run continuously, saving a large volume of logs without catching up or incrementing the pointer (due to the pagination loop). During this time CPU utilization significantly dropped while memory utilization increased by roughly 10%

What was more surprising to us was that other connectors would fail to start during this process, effectively blocking all other pipelines/connectors.

- Deployment: `local_process` via AWS ECS
- Output: AWS S3
- Cache: AWS DynamoDB
- Config: AWS SSM Parameter Store

It would be helpful for us to understand: Grove appears to be multithreaded for each connector being dispatched - why is it that without this PR, no other connectors appear to be dispatched while BigQuery logs are being paginated?