### PR TITLE
Feature: Use `window_end` as pointer when set.

### DIFF
--- a/grove/connectors/__init__.py
+++ b/grove/connectors/__init__.py
@@ -966,6 +966,7 @@ class BaseConnector:
         # rather than the pointer. This speeds things up, and prevents duplication after
         # failed collections.
         if self.window_end is not None:
+            self._pointer = self.window_end
             return self.window_end
 
         if self._pointer:

--- a/grove/connectors/__init__.py
+++ b/grove/connectors/__init__.py
@@ -967,7 +967,6 @@ class BaseConnector:
         # failed collections.
         if self.window_end is not None:
             self._pointer = self.window_end
-            return self.window_end
 
         if self._pointer:
             return self._pointer


### PR DESCRIPTION
## Overview

This pull-request enables the base connector to select and use the `window_end` value in place of the `pointer` when windowing is in use, and there is a `window_end` value in the cache. This is in order to ensure that logs are not recollected between collections, which should provide a speed up and prevent duplicate log record collection.

These code paths should only ever be hit in `REVERSE_CHRONOLOGICAL` mode - as windowing is not used outside of this mode.