### PR TITLE
Bigquery max batches fix

### DIFF
--- a/grove/connectors/google/bigquery_query.py
+++ b/grove/connectors/google/bigquery_query.py
@@ -33,7 +33,7 @@ class Connector(BaseConnector):
             dataset_name = self.configuration.dataset_name
             table_name = self.configuration.table_name
             columns = self.configuration.columns
-            max_batches = self.configuration.max_batches
+            max_batches = getattr(self.configuration, 'max_batches', 3)
             self.POINTER_PATH = self.configuration.pointer_path
 
             self.logger.debug("Configuration parameters:")
@@ -47,9 +47,6 @@ class Connector(BaseConnector):
                     "POINTER_PATH is not set in the configuration."
                 )
             
-            if max_batches is None:
-                max_batches = 3
-
             if not isinstance(max_batches, int) or max_batches <= 0:
                 raise ConfigurationException(
                     "max_batches must be a positive integer."

--- a/grove/connectors/google/bigquery_query.py
+++ b/grove/connectors/google/bigquery_query.py
@@ -97,9 +97,9 @@ class Connector(BaseConnector):
             query = f"""
             SELECT {', '.join(columns)}
             FROM `{project_id}.{dataset_name}.{table_name}`
-            WHERE TIMESTAMP(_PARTITIONTIME) > TIMESTAMP('{str_pointer}')
+            WHERE {self.POINTER_PATH} > {str_pointer}
             AND {self.POINTER_PATH} IS NOT NULL
-            ORDER BY TIMESTAMP(_PARTITIONTIME) ASC
+            ORDER BY {self.POINTER_PATH} ASC
             LIMIT 1000
             """
             self.logger.debug(f"Constructed query: {query}")

--- a/tests/test_connectors_google_bigquery_query.py
+++ b/tests/test_connectors_google_bigquery_query.py
@@ -105,3 +105,57 @@ class GoogleBigQueryQueryTestCase(unittest.TestCase):
         self.assertEqual(mock_client.query.call_count, 2)
         # Total logs saved: 1000 + 500 = 1500
         self.assertEqual(self.connector._saved["logs"], 1500)
+
+    @patch('grove.connectors.google.bigquery_query.bigquery.Client')
+    @patch.object(Connector, 'get_credentials')
+    def test_collect_without_max_batches(self, mock_get_creds, mock_bigquery_client):
+        """Test that the connector works when max_batches is not in config (uses default)."""
+        # Mock credentials
+        mock_get_creds.return_value = Mock()
+        
+        # Mock BigQuery client and query results
+        mock_client = Mock()
+        mock_bigquery_client.return_value = mock_client
+        
+        mock_query_job = Mock()
+        mock_client.query.return_value = mock_query_job
+        
+        # Mock query results - less than 1000 rows
+        mock_rows = [
+            {"timestamp_usec": 1738500089504000, "message": "Test log 1", "user_id": "user1"},
+            {"timestamp_usec": 1738500089505000, "message": "Test log 2", "user_id": "user2"},
+        ]
+        mock_query_job.result.return_value = mock_rows
+        
+        # Create connector WITHOUT max_batches in config
+        connector_without_max_batches = Connector(
+            config=ConnectorConfig(
+                identity="test-project",
+                key="{}",
+                name="test-bigquery-no-max-batches",
+                connector="google_bigquery_query",
+                project_id="test-project",
+                dataset_name="test_dataset",
+                table_name="test_table",
+                columns=["timestamp_usec", "message", "user_id"],
+                pointer_path="timestamp_usec"
+                # Note: no max_batches field - should default to 3
+            ),
+            context={
+                "runtime": "test_harness",
+                "runtime_id": "NA",
+            },
+        )
+        
+        # Set initial pointer
+        connector_without_max_batches._pointer = "1738500089504000"
+        
+        # Run collection - this should work with default max_batches=3
+        connector_without_max_batches.run()
+        
+        # Verify results
+        self.assertEqual(connector_without_max_batches._saved["logs"], 2)
+        
+        # Verify that the default value of 3 was used by checking the connector's behavior
+        # Since we only have 2 rows (< 1000), it should complete in one batch
+        self.assertEqual(mock_client.query.call_count, 1)


### PR DESCRIPTION
## Summary of Changes

### Bug Fixes
- **Fixed `max_batches` configuration error**
  - The connector currently works with `max_batches` set, but will error out if it is not set due to the placement of the logic for default value. This PR fixes that issue.
- **Updated query logic**: Replaced `_PARTITIONTIME` (which is not included on all bigquery tables) in the SQL query with the actual user-defined timestamp field specified in `POINTER_PATH`

