### PR TITLE
Time Format feature for Google BigQuery connector

### DIFF
--- a/grove/connectors/google/utils.py
+++ b/grove/connectors/google/utils.py
@@ -16,10 +16,10 @@ def as_bigquery_timestamp_microseconds(epoch_usec) -> str:
     # Convert to int if it's a string
     if isinstance(epoch_usec, str):
         epoch_usec = int(epoch_usec)
-    
+
     # Convert microseconds to seconds
     timestamp_seconds = epoch_usec / 1_000_000.0
-    
+
     dt = datetime.fromtimestamp(timestamp_seconds, tz=timezone.utc)
     # BigQuery expects "+00" not "+0000" or "+00:00"
     return dt.strftime("%Y-%m-%d %H:%M:%S+00")
@@ -35,7 +35,7 @@ def as_bigquery_timestamp_seconds(epoch_sec) -> str:
     # Convert to float if it's a string
     if isinstance(epoch_sec, str):
         epoch_sec = float(epoch_sec)
-    
+
     dt = datetime.fromtimestamp(epoch_sec, tz=timezone.utc)
     # BigQuery expects "+00" not "+0000" or "+00:00"
     return dt.strftime("%Y-%m-%d %H:%M:%S+00")
@@ -51,10 +51,10 @@ def as_bigquery_timestamp_milliseconds(epoch_msec) -> str:
     # Convert to int if it's a string
     if isinstance(epoch_msec, str):
         epoch_msec = int(epoch_msec)
-    
+
     # Convert milliseconds to seconds
     timestamp_seconds = epoch_msec / 1_000.0
-    
+
     dt = datetime.fromtimestamp(timestamp_seconds, tz=timezone.utc)
     # BigQuery expects "+00" not "+0000" or "+00:00"
-    return dt.strftime("%Y-%m-%d %H:%M:%S+00") 
+    return dt.strftime("%Y-%m-%d %H:%M:%S+00")

--- a/templates/configuration/google/bigquery.json
+++ b/templates/configuration/google/bigquery.json
@@ -8,6 +8,7 @@
     "dataset_name": "",
     "table_name": "",
     "pointer_path": "",
+    "time_format": "microseconds",
     "encoding": {
         "key": "base64"
     }

--- a/templates/configuration/google/bigquery_gmail.json
+++ b/templates/configuration/google/bigquery_gmail.json
@@ -8,6 +8,7 @@
     "dataset_name": "activity",
     "table_name": "activity",
     "pointer_path": "gmail.event_info.timestamp_usec",
+    "time_format": "microseconds",
     "encoding": {
         "key": "base64"
     }

--- a/tests/test_connectors_google_bigquery_query.py
+++ b/tests/test_connectors_google_bigquery_query.py
@@ -3,7 +3,6 @@
 
 """Implements unit tests for the Google BigQuery Query connector."""
 
-import json
 import os
 import unittest
 from unittest.mock import Mock, patch
@@ -11,7 +10,6 @@ from unittest.mock import Mock, patch
 from grove.connectors.google.bigquery_query import Connector
 from grove.models import ConnectorConfig
 from tests import mocks
-from grove.exceptions import ConfigurationException
 
 
 class GoogleBigQueryQueryTestCase(unittest.TestCase):

--- a/tests/test_connectors_google_bigquery_query.py
+++ b/tests/test_connectors_google_bigquery_query.py
@@ -11,6 +11,7 @@ from unittest.mock import Mock, patch
 from grove.connectors.google.bigquery_query import Connector
 from grove.models import ConnectorConfig
 from tests import mocks
+from grove.exceptions import ConfigurationException
 
 
 class GoogleBigQueryQueryTestCase(unittest.TestCase):
@@ -32,7 +33,6 @@ class GoogleBigQueryQueryTestCase(unittest.TestCase):
                 table_name="test_table",
                 columns=["timestamp_usec", "message", "user_id"],
                 pointer_path="timestamp_usec",
-                time_format="microseconds",
                 max_batches=1
             ),
             context={
@@ -139,8 +139,7 @@ class GoogleBigQueryQueryTestCase(unittest.TestCase):
                 dataset_name="test_dataset",
                 table_name="test_table",
                 columns=["timestamp_usec", "message", "user_id"],
-                pointer_path="timestamp_usec",
-                time_format="microseconds"
+                pointer_path="timestamp_usec"
                 # Note: no max_batches field - should default to 3
             ),
             context={
@@ -164,8 +163,8 @@ class GoogleBigQueryQueryTestCase(unittest.TestCase):
 
     @patch('grove.connectors.google.bigquery_query.bigquery.Client')
     @patch.object(Connector, 'get_credentials')
-    def test_collect_with_timestamp_format(self, mock_get_creds, mock_bigquery_client):
-        """Test collection with timestamp format (for _PARTITIONTIME scenarios)."""
+    def test_collect_no_pointer_timestamp_format(self, mock_get_creds, mock_bigquery_client):
+        """Ensure the connector works with timestamp format when no previous pointer exists."""
         # Mock credentials
         mock_get_creds.return_value = Mock()
         
@@ -176,43 +175,190 @@ class GoogleBigQueryQueryTestCase(unittest.TestCase):
         mock_query_job = Mock()
         mock_client.query.return_value = mock_query_job
         
-        # Mock query results
+        # Mock query results with timestamp format data
         mock_rows = [
-            {"_PARTITIONTIME": "2025-07-08 20:00:00+00", "message": "Test log 1"},
-            {"_PARTITIONTIME": "2025-07-08 21:00:00+00", "message": "Test log 2"},
+            {"created_at": "2025-01-01 10:00:00", "message": "Test log 1", "user_id": "user1"},
+            {"created_at": "2025-01-01 10:01:00", "message": "Test log 2", "user_id": "user2"},
+            {"created_at": "2025-01-01 10:02:00", "message": "Test log 3", "user_id": "user3"},
         ]
         mock_query_job.result.return_value = mock_rows
         
-        # Create connector with timestamp format
-        connector_timestamp = Connector(
-            config=ConnectorConfig(
-                identity="test-project",
-                key="{}",
-                name="test-bigquery-timestamp",
-                connector="google_bigquery_query",
-                project_id="test-project",
-                dataset_name="test_dataset",
-                table_name="test_table",
-                columns=["_PARTITIONTIME", "message"],
-                pointer_path="_PARTITIONTIME",
-                time_format="timestamp"
-            ),
-            context={
-                "runtime": "test_harness",
-                "runtime_id": "NA",
-            },
-        )
+        # Adjust self.connector's configuration for this test
+        self.connector.configuration.pointer_path = "created_at"
+        self.connector.configuration.columns = ["*"]
+        self.connector.configuration.time_format = "timestamp"
+        self.connector.configuration.max_batches = 10
         
-        # Set initial pointer
-        connector_timestamp._pointer = "1738500089504000"
+        # Ensure no pointer exists (should be empty string initially)
+        self.connector._pointer = ""
         
         # Run collection
-        connector_timestamp.run()
+        self.connector.run()
         
         # Verify results
-        self.assertEqual(connector_timestamp._saved["logs"], 2)
+        self.assertEqual(self.connector._saved["logs"], 3)
         
-        # Verify the query was constructed with timestamp format
-        # The query should use TIMESTAMP() function for comparison
+        # Verify that the query was called once (no pagination needed for 3 rows)
+        self.assertEqual(mock_client.query.call_count, 1)
+        
+        # Verify the query was called with appropriate parameters
+        mock_client.query.assert_called_once()
         call_args = mock_client.query.call_args[0][0]
-        self.assertIn("TIMESTAMP", call_args)
+        
+        # Check that the query includes the table reference
+        self.assertIn("test_dataset.test_table", call_args)
+        
+        # Check that the query includes ORDER BY for the pointer path
+        self.assertIn("ORDER BY created_at", call_args)
+        
+        # Check that the query includes LIMIT for pagination
+        self.assertIn("LIMIT 1000", call_args)
+
+    @patch('grove.connectors.google.bigquery_query.bigquery.Client')
+    @patch.object(Connector, 'get_credentials')
+    def test_collect_timestamp_format_with_pointer(self, mock_get_creds, mock_bigquery_client):
+        """Ensure the connector works with timestamp format when a previous pointer exists."""
+        # Mock credentials
+        mock_get_creds.return_value = Mock()
+        
+        # Mock BigQuery client and query results
+        mock_client = Mock()
+        mock_bigquery_client.return_value = mock_client
+        
+        mock_query_job = Mock()
+        mock_client.query.return_value = mock_query_job
+        
+        # Mock query results with timestamp format data
+        mock_rows = [
+            {"created_at": "2025-01-01 11:00:00", "message": "Test log 4", "user_id": "user4"},
+            {"created_at": "2025-01-01 11:01:00", "message": "Test log 5", "user_id": "user5"},
+        ]
+        mock_query_job.result.return_value = mock_rows
+        
+        # Adjust self.connector's configuration for this test
+        self.connector.configuration.pointer_path = "created_at"
+        self.connector.configuration.columns = ["*"]
+        self.connector.configuration.time_format = "timestamp"
+        self.connector.configuration.max_batches = 10
+        
+        # Set existing pointer in timestamp format
+        self.connector._pointer = "2025-01-01 10:00:00"
+        
+        # Run collection
+        self.connector.run()
+        
+        # Verify results
+        self.assertEqual(self.connector._saved["logs"], 2)
+        
+        # Verify that the query was called once
+        self.assertEqual(mock_client.query.call_count, 1)
+        
+        # Verify the query was called with appropriate parameters
+        mock_client.query.assert_called_once()
+        call_args = mock_client.query.call_args[0][0]
+        
+        # Check that the query includes the timestamp comparison
+        self.assertIn("created_at > TIMESTAMP('2025-01-01 10:00:00')", call_args)
+        
+        # Check that the query includes ORDER BY for the pointer path
+        self.assertIn("ORDER BY created_at", call_args)
+
+    @patch('grove.connectors.google.bigquery_query.bigquery.Client')
+    @patch.object(Connector, 'get_credentials')
+    def test_collect_invalid_pointer_formats(self, mock_get_creds, mock_bigquery_client):
+        """Ensure the connector handles invalid pointer formats by falling back to default."""
+        # Mock credentials
+        mock_get_creds.return_value = Mock()
+        
+        # Mock BigQuery client and query results
+        mock_client = Mock()
+        mock_bigquery_client.return_value = mock_client
+        
+        mock_query_job = Mock()
+        mock_client.query.return_value = mock_query_job
+        
+        # Mock empty query results (no more data after default pointer)
+        mock_query_job.result.return_value = []
+        
+        # Test 1: Invalid microseconds pointer (non-integer) - should fall back to default
+        self.connector.configuration.time_format = "microseconds"
+        self.connector._pointer = "not_a_number"
+        
+        # Run collection - should not raise exception, should fall back to default
+        self.connector.run()
+        
+        # Verify that the query was called with a default microseconds pointer
+        self.assertEqual(mock_client.query.call_count, 1)
+        call_args = mock_client.query.call_args[0][0]
+        
+        # Should contain a valid microseconds value (7 days ago)
+        self.assertIn("timestamp_usec > ", call_args)
+        # Extract the microseconds value and verify it's a number
+        import re
+        match = re.search(r'timestamp_usec > (\d+)', call_args)
+        self.assertIsNotNone(match)
+        microseconds_value = int(match.group(1))
+        self.assertGreater(microseconds_value, 0)
+        
+        # Reset for next test
+        mock_client.reset_mock()
+        
+        # Test 2: Invalid timestamp pointer (malformed date) - should fall back to default
+        self.connector.configuration.time_format = "timestamp"
+        self.connector.configuration.pointer_path = "created_at"
+        self.connector._pointer = "invalid-date-format"
+        
+        # Run collection - should not raise exception, should fall back to default
+        self.connector.run()
+        
+        # Verify that the query was called with a default timestamp pointer
+        self.assertEqual(mock_client.query.call_count, 1)
+        call_args = mock_client.query.call_args[0][0]
+        
+        # Should contain a valid timestamp value (7 days ago)
+        self.assertIn("created_at > TIMESTAMP('", call_args)
+        # Extract the timestamp value and verify it's a valid format
+        match = re.search(r"TIMESTAMP\('([^']+)'\)", call_args)
+        self.assertIsNotNone(match)
+        timestamp_value = match.group(1)
+        # Should be in format YYYY-MM-DD HH:MM:SS+00
+        self.assertRegex(timestamp_value, r'\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\+00')
+
+    @patch('grove.connectors.google.bigquery_query.bigquery.Client')
+    @patch.object(Connector, 'get_credentials')
+    def test_collect_no_results(self, mock_get_creds, mock_bigquery_client):
+        """Ensure the connector handles empty results gracefully."""
+        # Mock credentials
+        mock_get_creds.return_value = Mock()
+        
+        # Mock BigQuery client and query results
+        mock_client = Mock()
+        mock_bigquery_client.return_value = mock_client
+        
+        mock_query_job = Mock()
+        mock_client.query.return_value = mock_query_job
+        
+        # Mock empty query results
+        mock_query_job.result.return_value = []
+        
+        # Set initial pointer
+        self.connector._pointer = "1738500089504000"
+        
+        # Run collection
+        self.connector.run()
+        
+        # Verify that no logs were saved
+        self.assertEqual(self.connector._saved["logs"], 0)
+        
+        # Verify that the query was called once
+        self.assertEqual(mock_client.query.call_count, 1)
+        
+        # Verify the query was called with appropriate parameters
+        mock_client.query.assert_called_once()
+        call_args = mock_client.query.call_args[0][0]
+        
+        # Check that the query includes the table reference
+        self.assertIn("test_dataset.test_table", call_args)
+        
+        # Check that the query includes the pointer comparison
+        self.assertIn("timestamp_usec > 1738500089504000", call_args)


### PR DESCRIPTION
### Features/Improvements for Google BigQuery connector


- `max_batches` configuration: Changed from direct attribute access to getattr() with default value of 3
- Optimized SQL syntax: Uses only the user-specified `pointer_path` for queries
- Added support for timestamp as well as epoch microseconds formats for `pointer_path`
  - `time_format` is now a mandatory field
