### PR TITLE
Add owner to GitHub rule entries

### DIFF
--- a/grove/connectors/github/api.py
+++ b/grove/connectors/github/api.py
@@ -183,6 +183,8 @@ class Client:
 
             # Grab a list of all ruleset identifiers.
             for entry in result.body:
+                entry["owner"] = self.scope # add owner to entry
+
                 rulesets.append(entry.get("id"))
 
                 if after:


### PR DESCRIPTION
GitHub rule event contain a `repository_name` but no user or org (https://docs.github.com/en/rest/repos/rule-suites?apiVersion=2022-11-28). 

Adding the `scope` as a `owner` helps to identify the correct repository downstream.