### PR TITLE
Move to ProcessPoolExecutor for Daemon

### DIFF
--- a/grove/connectors/__init__.py
+++ b/grove/connectors/__init__.py
@@ -62,9 +62,11 @@ class BaseConnector:
             when configuring this connector.
         :param context: Contextual information relating to the current runtime.
         """
-        self.logger = logging.getLogger(__name__)
         self.configuration = config
         self.runtime_context = context
+
+        # Use the caller provided logger - if present.
+        self.logger = logging.getLogger(__name__)
 
         # Track the time our execution started. We use this quite a lot to ensure we
         # are using a consistent timestamp between executions.

--- a/grove/constants.py
+++ b/grove/constants.py
@@ -23,6 +23,9 @@ LOCK_DATE_FORMAT = "%Y-%m-%dT%H:%M:%S.%fZ"
 CHRONOLOGICAL = "CHRONOLOGICAL"
 REVERSE_CHRONOLOGICAL = "REVERSE_CHRONOLOGICAL"
 
+# Root logger name.
+GROVE_LOGGER_ROOT = "grove"
+
 # Specify the key under which grove metadata will be appended to a log entry.
 GROVE_METADATA_KEY = "_grove"
 
@@ -35,6 +38,7 @@ ENV_GROVE_TELEMETRY_URI = "GROVE_TELEMETRY_URI"
 ENV_GROVE_WORKER_COUNT = "GROVE_WORKER_COUNT"
 ENV_GROVE_LOCK_DURATION = "GROVE_LOCK_DURATION"
 ENV_GROVE_CONFIG_REFRESH = "GROVE_CONFIG_REFRESH"
+ENV_GROVE_LOG_LEVEL = "LOG_LEVEL"
 
 # Plugin groups (setuptools entrypoints).
 PLUGIN_GROUP_CACHE = "grove.caches"
@@ -48,6 +52,7 @@ PLUGIN_GROUP_CONNECTOR = "grove.connectors"
 DEFAULT_CACHE_HANDLER = "local_memory"
 DEFAULT_OUTPUT_HANDLER = "local_stdout"
 DEFAULT_CONFIG_HANDLER = "local_file"
+DEFAULT_LOG_LEVEL = "INFO"
 
 # Maximum number of connectors to execute concurrently.
 DEFAULT_WORKER_COUNT = 50

--- a/grove/entrypoints/base.py
+++ b/grove/entrypoints/base.py
@@ -17,6 +17,7 @@ from grove.constants import (
     ENV_GROVE_CONFIG_HANDLER,
     ENV_GROVE_SECRET_HANDLER,
     ENV_GROVE_WORKER_COUNT,
+    GROVE_LOGGER_ROOT,
     PLUGIN_GROUP_CONFIG,
     PLUGIN_GROUP_CONNECTOR,
     PLUGIN_GROUP_SECRET,
@@ -86,7 +87,7 @@ def entrypoint(context: Dict[str, Any]):
     :param context: Contextual information relating to the current runtime.
     """
     logger = Logger(
-        "grove",
+        GROVE_LOGGER_ROOT,
         logger_formatter=GroveFormatter(context),
         stream=sys.stderr,
     )

--- a/grove/entrypoints/local_daemon.py
+++ b/grove/entrypoints/local_daemon.py
@@ -3,22 +3,25 @@
 
 """Grove local daemon entrypoint."""
 
-import copy
 import datetime
+import logging
 import os
 import socket
 import sys
 import time
-from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import ProcessPoolExecutor
+from logging.handlers import QueueHandler, QueueListener
+from multiprocessing import Queue
 from typing import Dict
-
-from aws_lambda_powertools import Logger
 
 from grove.constants import (
     DEFAULT_CONFIG_REFRESH,
+    DEFAULT_LOG_LEVEL,
     DEFAULT_WORKER_COUNT,
     ENV_GROVE_CONFIG_REFRESH,
+    ENV_GROVE_LOG_LEVEL,
     ENV_GROVE_WORKER_COUNT,
+    GROVE_LOGGER_ROOT,
 )
 from grove.entrypoints import base
 from grove.exceptions import ConcurrencyException, GroveException
@@ -46,6 +49,20 @@ def runtime_information() -> Dict[str, str]:
     }
 
 
+def initialise_worker(queue: Queue):
+    """Initialise a Grove worker.
+
+    Each configured connector is dispatched to a worker by the Grove daemon.
+    """
+    level = str(os.environ.get(ENV_GROVE_LOG_LEVEL, DEFAULT_LOG_LEVEL)).upper()
+    logger = logging.getLogger(GROVE_LOGGER_ROOT)
+
+    # Push all log messages into a queue, rather than attempting to emit directly.
+    handler = QueueHandler(queue)
+    logger.setLevel(level)
+    logger.addHandler(handler)
+
+
 def entrypoint():
     """Provides the daemon entrypoint for Grove.
 
@@ -56,15 +73,30 @@ def entrypoint():
     It may be possible to rationalise the two in future, but for now, we'll keep
     things separate.
     """
-    context = {"runtime": __file__, **runtime_information()}
-    logger = Logger(
-        "grove",
-        logger_formatter=GroveFormatter(context),
-        stream=sys.stderr,
-    )
-    logger.info("Grove started")
+    context = {
+        "runtime": __file__,
+        **runtime_information(),
+    }
+
+    # Setup a logging destination which will monitor a queue for log messages. This
+    # allows for each connector, running as separate processes, to log to a common
+    # destination.
+    log_queue = Queue()
+    log_handler = logging.StreamHandler(stream=sys.stderr)
+    log_handler.setFormatter(GroveFormatter(context=context))
+
+    # Setup the logging thread.
+    log_thread = QueueListener(log_queue, log_handler)
+    log_thread.start()
+
+    # Setup a logger for the main thread.
+    logger = logging.getLogger(GROVE_LOGGER_ROOT)
+    logger.setLevel(str(os.environ.get(ENV_GROVE_LOG_LEVEL, DEFAULT_LOG_LEVEL)).upper())
+    logger.addHandler(QueueHandler(log_queue))
 
     # Get the configuration refresh frequency.
+    logger.info("Grove started")
+
     try:
         refreshed_at = None
         since_refresh = None
@@ -95,7 +127,11 @@ def entrypoint():
     # workers specified by the worker count.
     logger.info("Spawning thread pool for connectors", extra={"workers": workers})
 
-    with ThreadPoolExecutor(max_workers=workers) as pool:
+    with ProcessPoolExecutor(
+        max_workers=workers,
+        initializer=initialise_worker,
+        initargs=(log_queue,),
+    ) as pool:
         runs: Dict[str, Run] = {}
         while True:
             if refreshed_at:
@@ -159,7 +195,7 @@ def entrypoint():
                         continue
 
                     # Sync last run time from connector completion.
-                    run.last = copy.copy(run.future.result())
+                    run.last = run.future.result()
                 except ConcurrencyException:
                     # We don't consider concurrency to be abnormal - as it may indicate
                     # another worker has scheduled the connector before us.


### PR DESCRIPTION
## Overview

This pull-request moves the Grove daemon mode (`groved`) to use a `ProcessPoolExecutor` in place of `ThreadPoolExecutor`.

Although connectors are more likely to be I/O bound, the use of multiprocessing should enable for more granular resource limits to be applied per connector in future.