### PR TITLE
Add Launchdarkly Audit Log Connector

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ isn't listed here, support can be added by creating a custom connector!
 * GSuite alerts
 * GSuite activity logs
 * GSuite Usage Reports
+* LaunchDarkly audit records
 * Okta system logs
 * Oomnitza activity logs
 * 1Password sign-in attempt logs

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -54,6 +54,7 @@ isn't listed here, support can be added by creating a custom connector!
 * GitHub audit logs
 * GSuite alerts
 * GSuite activity logs
+* LaunchDarkly audit records
 * Okta system logs
 * Oomnitza activity logs
 * 1Password sign-in attempt logs

--- a/grove/connectors/launchdarkly/__init__.py
+++ b/grove/connectors/launchdarkly/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+"""LaunchDarkly connectors for Grove."""

--- a/grove/connectors/launchdarkly/api.py
+++ b/grove/connectors/launchdarkly/api.py
@@ -1,0 +1,135 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+"""LaunchDarkly Audit API client."""
+
+import logging
+import time
+from typing import Any, Dict, Optional
+from jmespath import search
+
+import requests
+
+from grove.exceptions import RateLimitException, RequestFailedException
+from grove.types import AuditLogEntries, HTTPResponse
+
+API_BASE_URI = "https://app.launchdarkly.com"
+
+
+class Client:
+    def __init__(
+        self,
+        token: Optional[str] = None,
+        retry: Optional[bool] = True,
+    ):
+        """Setup a new client.
+
+        :param token: The LaunchDarkly API Key.
+        :param retry: Whether to automatically retry if recoverable errors are
+            encountered, such as rate-limiting.
+        """
+        self.retry = retry
+        self.logger = logging.getLogger(__name__)
+        self.headers = {
+            "Authorization": f"{token}"
+        }
+
+    def _get(
+        self,
+        url: str,
+        params: Optional[Dict[str, Optional[str]]] = None,
+    ) -> HTTPResponse:
+        """A GET wrapper to handle retries for the caller.
+
+        :param url: URL to perform the HTTP GET against.
+        :param params: HTTP parameters to add to the request.
+
+        :raises RateLimitException: A rate limit was encountered.
+        :raises RequestFailedException: An HTTP request failed.
+
+        :return: HTTP Response object containing the headers and body of a response.
+        """
+        while True:
+            try:
+                u = url
+                v = self.headers
+                w = params
+                response = requests.get(u, headers=v, params=w)
+                response.raise_for_status()
+                break
+            except requests.exceptions.RequestException as err:
+                # Retry on rate-limit, but only if requested.
+                if getattr(err.response, "status_code", None) == 429:
+                    self.logger.warning("Rate-limit was exceeded during request")
+                    if self.retry:
+                        time.sleep(1)
+                        continue
+                    else:
+                        raise RateLimitException(err)
+
+                raise RequestFailedException(err)
+
+        return HTTPResponse(headers=response.headers, body=response.json())
+
+    def get_audit_record_id(
+            self,
+            id: str
+    ) -> HTTPResponse:
+        url = f"{API_BASE_URI}/api/v2/auditlog/{id}"
+        return self._get(url)
+
+    def get_audit_records_list(
+        self,
+        cursor: Optional[str] = None,
+        before: Optional[str] = None,
+        after: Optional[str] = None,
+        limit: Optional[str] = None,
+        q: Optional[str] = None,
+        spec: Optional[str] = None
+    ) -> AuditLogEntries:
+        """Fetches a list of audit logs which match the provided filters.
+
+        :param cursor: The cursor to use when paging.
+        :param before: A timestamp filter, expressed as a Unix epoch time in milliseconds. All entries this returns occurred before the timestamp.
+        :param after: A timestamp filter, expressed as a Unix epoch time in milliseconds. All entries this returns occurred after the timestamp.
+        :param limit: A limit on the number of audit log entries that return. Set between 1 and 20. The default is 10.
+        :param q: Text to search for. You can search for the full or partial name of the resource.
+        :param spec: A resource specifier that lets you filter audit log listings by resource
+
+        :return: AuditLogEntries object containing a pagination cursor, and log entries.
+        """
+        # See psf/requests issue #2651 for why we can happily pass in None values
+        # and not have the request key added to the URI.
+
+        if cursor is None:
+            url = f"{API_BASE_URI}/api/v2/auditlog"
+            result = self._get(
+                url,
+                params={
+                    "before": before,
+                    "after": after,
+                    "limit": limit,
+                    "q": q,
+                    "spec": spec,
+                },
+            )
+        else:
+            url = f"{API_BASE_URI}{cursor}"
+            result = self._get(url)
+
+        # Record the cursor, if set.
+        cursor = result.body.get("_links", {}).get("next", {}).get("href")
+
+        # Pull the list of ids out of the returned results list
+        ids = search("items[*]._id", result.body)
+
+        # Iterate through the list of IDs to fetch each detailed audit record
+        results: list[dict[str, Any]] = []
+
+        for id in ids:
+            record = self.get_audit_record_id(id)
+            results.append(record.body)
+
+        # Return the cursor and the results to allow the caller to page as required.
+        return AuditLogEntries(cursor=cursor, entries=results)
+

--- a/grove/connectors/launchdarkly/audit_records.py
+++ b/grove/connectors/launchdarkly/audit_records.py
@@ -1,0 +1,52 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+"""launchdarkly Audit connector for Grove."""
+
+from time import time
+from typing import Optional
+
+from grove.connectors import BaseConnector
+from grove.connectors.launchdarkly.api import Client
+from grove.constants import CHRONOLOGICAL
+from grove.exceptions import NotFoundException
+
+
+class Connector(BaseConnector):
+    CONNECTOR = "launchdarkly_audit_records"
+    POINTER_PATH = "date"
+    LOG_ORDER = CHRONOLOGICAL
+
+    def collect(self):
+        """Collects launchdarkly audit records from the launchdarkly API.
+
+        https://launchdarkly.com/docs/api/audit-log/get-audit-log-entries
+        https://launchdarkly.com/docs/api/audit-log/get-audit-log-entry
+
+        This will first check whether there are any pointers cached to indicate previous
+        collections. If not, the last week of data will be collected.
+        """
+        client = Client(token=self.key)
+        cursor: Optional[str] = None
+
+        # If no pointer is stored then a previous run hasn't been performed, so set the
+        # pointer to a week ago. In the case of the launchdarkly audit API the pointer is
+        # the value of the "date" field from the latest record retrieved from
+        # the API.
+        try:
+            _ = self.pointer
+        except NotFoundException:
+            since = round((time() * 1000) - 604800000) # Current time minus 7 days in epoch time
+            self.pointer = str(since)
+
+        # Get log data from the upstream API, paging as required.
+        while True:
+            log = client.get_audit_records_list(cursor=cursor, before=None, after=self.pointer, limit="10")
+
+            # Save this batch of log entries.
+            self.save(log.entries)
+
+            # Check if we need to continue paging.
+            cursor = str(log.cursor) if log.cursor is not None else None
+            if cursor is None:
+                break

--- a/grove/connectors/launchdarkly/audit_records.py
+++ b/grove/connectors/launchdarkly/audit_records.py
@@ -8,14 +8,14 @@ from typing import Optional
 
 from grove.connectors import BaseConnector
 from grove.connectors.launchdarkly.api import Client
-from grove.constants import CHRONOLOGICAL
+from grove.constants import REVERSE_CHRONOLOGICAL
 from grove.exceptions import NotFoundException
 
 
 class Connector(BaseConnector):
     CONNECTOR = "launchdarkly_audit_records"
     POINTER_PATH = "date"
-    LOG_ORDER = CHRONOLOGICAL
+    LOG_ORDER = REVERSE_CHRONOLOGICAL
 
     def collect(self):
         """Collects launchdarkly audit records from the launchdarkly API.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "boto3>=1.26,<2.0",
     "requests>=2.28,<3.0",
     "google-api-python-client>=2.68,<3.0",
-    "simple-salesforce>=1.12,<2.0",
+    "simple-salesforce>=1.12,<1.12.7",
     "snowflake-connector-python>=3.12.2,<4.0",
     "twilio>=7.15,<8.0",
     "pydantic>=1.10,<2.0",
@@ -65,7 +65,6 @@ local_daemon = "grove.entrypoints.local_daemon:entrypoint"
 local_process = "grove.entrypoints.local_process:entrypoint"
 
 [project.entry-points."grove.connectors"]
-quay_organization_logs = "grove.connectors.quay.organization_logs:Connector"
 fleetdm_host_logs = "grove.connectors.fleetdm.host_logs:Connector"
 atlassian_audit_events = "grove.connectors.atlassian.audit_events:Connector"
 google_bigquery_query = "grove.connectors.google.bigquery_query:Connector"
@@ -76,6 +75,7 @@ gsuite_activities = "grove.connectors.gsuite.activities:Connector"
 gsuite_usage = "grove.connectors.gsuite.usage:Connector"
 local_heartbeat = "grove.connectors.local.heartbeat:Connector"
 gsuite_alerts = "grove.connectors.gsuite.alerts:Connector"
+launchdarkly_audit_records = "grove.connectors.launchdarkly.audit_records:Connector"
 okta_system_log = "grove.connectors.okta.system_log:Connector"
 onepassword_events_itemusages = "grove.connectors.onepassword.events_itemusages:Connector"
 onepassword_events_signinattempts = "grove.connectors.onepassword.events_signinattempts:Connector"

--- a/templates/configuration/launchdarkly/audit_records.json
+++ b/templates/configuration/launchdarkly/audit_records.json
@@ -1,0 +1,6 @@
+{
+    "key": "BEARER_TOKEN_HERE",
+    "identity": "ORGANIZATION_ID",
+    "name": "launchdarkly-audit-records-example",
+    "connector": "launchdarkly_audit_records"
+}

--- a/tests/fixtures/launchdarkly/audit_log_item_1.json
+++ b/tests/fixtures/launchdarkly/audit_log_item_1.json
@@ -9,7 +9,7 @@
       "type": "application/json"
     },
     "self": {
-      "href": "/api/v2/auditlog/abc111abc111aaa",
+      "href": "/api/v2/auditlog/entry-def456",
       "type": "application/json"
     },
     "site": {
@@ -17,9 +17,9 @@
       "type": "text/html"
     }
   },
-  "_id": "abc111abc111aaa",
-  "_accountId": "accountid111",
-  "date": 1755508937731,
+  "_id": "entry-def456",
+  "_accountId": "account-789ghi",
+  "date": 1755692329415,
   "accesses": [
     {
       "action": "deactivateScimMember",

--- a/tests/fixtures/launchdarkly/audit_log_item_1.json
+++ b/tests/fixtures/launchdarkly/audit_log_item_1.json
@@ -1,0 +1,107 @@
+{
+  "_links": {
+    "canonical": {
+      "href": "/api/v2/members/member111",
+      "type": "application/json"
+    },
+    "parent": {
+      "href": "/api/v2/auditlog",
+      "type": "application/json"
+    },
+    "self": {
+      "href": "/api/v2/auditlog/abc111abc111aaa",
+      "type": "application/json"
+    },
+    "site": {
+      "href": "/settings/members/member111/permissions",
+      "type": "text/html"
+    }
+  },
+  "_id": "abc111abc111aaa",
+  "_accountId": "accountid111",
+  "date": 1755508937731,
+  "accesses": [
+    {
+      "action": "deactivateScimMember",
+      "resource": "member/member111"
+    }
+  ],
+  "kind": "member",
+  "name": "UserFirstName UserLastName1",
+  "description": "* Deactivated the member\n",
+  "shortDescription": "",
+  "app": {
+    "_links": {
+      "external": {
+        "href": "https://www.okta.com/",
+        "type": "text/html"
+      },
+      "parent": {
+        "href": "/internal/account/oauth2/applications",
+        "type": "application/json"
+      },
+      "self": {
+        "href": "/internal/account/oauth2/applications/oath-uuid-1==",
+        "type": "application/json"
+      },
+      "site": {
+        "href": "/settings/authorization/oauth/oath-uuid-1==/review",
+        "type": "application/json"
+      }
+    },
+    "_id": "oath-uuid-1==",
+    "isScim": true,
+    "name": "Okta",
+    "maintainerName": "okta"
+  },
+  "titleVerb": "deactivated the member",
+  "title": "Deactivated the member [UserFirstName UserLastName1](https://app.launchdarkly.com/settings/members/member111/permissions) \\(via API\\)",
+  "target": {
+    "_links": {
+      "canonical": {
+        "href": "/api/v2/members/member111",
+        "type": "application/json"
+      },
+      "site": {
+        "href": "/settings/members/member111/permissions",
+        "type": "text/html"
+      }
+    },
+    "name": "UserFirstName UserLastName1",
+    "resources": [
+      "member/member111"
+    ]
+  },
+  "currentVersion": {
+    "_links": {
+      "parent": {
+        "href": "/api/v2/members",
+        "type": "application/json"
+      },
+      "self": {
+        "href": "/api/v2/members/member111",
+        "type": "application/json"
+      },
+      "sendMfaEnableRequest": {
+        "href": "/api/v2/members/member111/mfa/request",
+        "type": "application/json"
+      }
+    },
+    "_id": "member111",
+    "firstName": "UserFirstName1",
+    "lastName": "UserLastName1",
+    "role": "writer",
+    "email": "UserFirstName1.UserLastName1@example.com",
+    "_pendingInvite": false,
+    "_verified": true,
+    "isBeta": false,
+    "customRoles": [],
+    "mfa": "disabled",
+    "excludedDashboards": [],
+    "_lastSeen": null,
+    "creationDate": 1748471259263,
+    "scimExternalId": "scimExternalId1",
+    "scimUsername": "UserFirstName1.UserLastName1@example.com",
+    "version": 25
+  }
+}

--- a/tests/fixtures/launchdarkly/audit_log_item_2.json
+++ b/tests/fixtures/launchdarkly/audit_log_item_2.json
@@ -1,0 +1,107 @@
+{
+  "_links": {
+    "canonical": {
+      "href": "/api/v2/members/member222",
+      "type": "application/json"
+    },
+    "parent": {
+      "href": "/api/v2/auditlog",
+      "type": "application/json"
+    },
+    "self": {
+      "href": "/api/v2/auditlog/abc222abc222aaa",
+      "type": "application/json"
+    },
+    "site": {
+      "href": "/settings/members/member222/permissions",
+      "type": "text/html"
+    }
+  },
+  "_id": "abc222abc222aaa",
+  "_accountId": "accountid222",
+  "date": 1755508937732,
+  "accesses": [
+    {
+      "action": "deactivateScimMember",
+      "resource": "member/member222"
+    }
+  ],
+  "kind": "member",
+  "name": "UserFirstName UserLastName1",
+  "description": "* Deactivated the member\n",
+  "shortDescription": "",
+  "app": {
+    "_links": {
+      "external": {
+        "href": "https://www.okta.com/",
+        "type": "text/html"
+      },
+      "parent": {
+        "href": "/internal/account/oauth2/applications",
+        "type": "application/json"
+      },
+      "self": {
+        "href": "/internal/account/oauth2/applications/oath-uuid-1==",
+        "type": "application/json"
+      },
+      "site": {
+        "href": "/settings/authorization/oauth/oath-uuid-1==/review",
+        "type": "application/json"
+      }
+    },
+    "_id": "oath-uuid-1==",
+    "isScim": true,
+    "name": "Okta",
+    "maintainerName": "okta"
+  },
+  "titleVerb": "deactivated the member",
+  "title": "Deactivated the member [UserFirstName UserLastName1](https://app.launchdarkly.com/settings/members/member222/permissions) \\(via API\\)",
+  "target": {
+    "_links": {
+      "canonical": {
+        "href": "/api/v2/members/member222",
+        "type": "application/json"
+      },
+      "site": {
+        "href": "/settings/members/member222/permissions",
+        "type": "text/html"
+      }
+    },
+    "name": "UserFirstName UserLastName1",
+    "resources": [
+      "member/member222"
+    ]
+  },
+  "currentVersion": {
+    "_links": {
+      "parent": {
+        "href": "/api/v2/members",
+        "type": "application/json"
+      },
+      "self": {
+        "href": "/api/v2/members/member222",
+        "type": "application/json"
+      },
+      "sendMfaEnableRequest": {
+        "href": "/api/v2/members/member222/mfa/request",
+        "type": "application/json"
+      }
+    },
+    "_id": "member222",
+    "firstName": "UserFirstName1",
+    "lastName": "UserLastName1",
+    "role": "writer",
+    "email": "UserFirstName1.UserLastName1@example.com",
+    "_pendingInvite": false,
+    "_verified": true,
+    "isBeta": false,
+    "customRoles": [],
+    "mfa": "disabled",
+    "excludedDashboards": [],
+    "_lastSeen": null,
+    "creationDate": 1748471259263,
+    "scimExternalId": "scimExternalId1",
+    "scimUsername": "UserFirstName1.UserLastName1@example.com",
+    "version": 25
+  }
+}

--- a/tests/fixtures/launchdarkly/audit_log_item_2.json
+++ b/tests/fixtures/launchdarkly/audit_log_item_2.json
@@ -9,7 +9,7 @@
       "type": "application/json"
     },
     "self": {
-      "href": "/api/v2/auditlog/abc222abc222aaa",
+      "href": "/api/v2/auditlog/entry-jkl789",
       "type": "application/json"
     },
     "site": {
@@ -17,9 +17,9 @@
       "type": "text/html"
     }
   },
-  "_id": "abc222abc222aaa",
-  "_accountId": "accountid222",
-  "date": 1755508937732,
+  "_id": "entry-jkl789",
+  "_accountId": "account-789ghi",
+  "date": 1755690378459,
   "accesses": [
     {
       "action": "deactivateScimMember",

--- a/tests/fixtures/launchdarkly/audit_log_item_3.json
+++ b/tests/fixtures/launchdarkly/audit_log_item_3.json
@@ -9,7 +9,7 @@
       "type": "application/json"
     },
     "self": {
-      "href": "/api/v2/auditlog/abc333abc333aaa",
+      "href": "/api/v2/auditlog/entry-stu012",
       "type": "application/json"
     },
     "site": {
@@ -17,9 +17,9 @@
       "type": "text/html"
     }
   },
-  "_id": "abc333abc333aaa",
-  "_accountId": "accountid333",
-  "date": 1755508937733,
+  "_id": "entry-stu012",
+  "_accountId": "account-789ghi",
+  "date": 1755690085032,
   "accesses": [
     {
       "action": "deactivateScimMember",

--- a/tests/fixtures/launchdarkly/audit_log_item_3.json
+++ b/tests/fixtures/launchdarkly/audit_log_item_3.json
@@ -1,0 +1,107 @@
+{
+  "_links": {
+    "canonical": {
+      "href": "/api/v2/members/member333",
+      "type": "application/json"
+    },
+    "parent": {
+      "href": "/api/v2/auditlog",
+      "type": "application/json"
+    },
+    "self": {
+      "href": "/api/v2/auditlog/abc333abc333aaa",
+      "type": "application/json"
+    },
+    "site": {
+      "href": "/settings/members/member333/permissions",
+      "type": "text/html"
+    }
+  },
+  "_id": "abc333abc333aaa",
+  "_accountId": "accountid333",
+  "date": 1755508937733,
+  "accesses": [
+    {
+      "action": "deactivateScimMember",
+      "resource": "member/member333"
+    }
+  ],
+  "kind": "member",
+  "name": "UserFirstName UserLastName1",
+  "description": "* Deactivated the member\n",
+  "shortDescription": "",
+  "app": {
+    "_links": {
+      "external": {
+        "href": "https://www.okta.com/",
+        "type": "text/html"
+      },
+      "parent": {
+        "href": "/internal/account/oauth2/applications",
+        "type": "application/json"
+      },
+      "self": {
+        "href": "/internal/account/oauth2/applications/oath-uuid-1==",
+        "type": "application/json"
+      },
+      "site": {
+        "href": "/settings/authorization/oauth/oath-uuid-1==/review",
+        "type": "application/json"
+      }
+    },
+    "_id": "oath-uuid-1==",
+    "isScim": true,
+    "name": "Okta",
+    "maintainerName": "okta"
+  },
+  "titleVerb": "deactivated the member",
+  "title": "Deactivated the member [UserFirstName UserLastName1](https://app.launchdarkly.com/settings/members/member333/permissions) \\(via API\\)",
+  "target": {
+    "_links": {
+      "canonical": {
+        "href": "/api/v2/members/member333",
+        "type": "application/json"
+      },
+      "site": {
+        "href": "/settings/members/member333/permissions",
+        "type": "text/html"
+      }
+    },
+    "name": "UserFirstName UserLastName1",
+    "resources": [
+      "member/member333"
+    ]
+  },
+  "currentVersion": {
+    "_links": {
+      "parent": {
+        "href": "/api/v2/members",
+        "type": "application/json"
+      },
+      "self": {
+        "href": "/api/v2/members/member333",
+        "type": "application/json"
+      },
+      "sendMfaEnableRequest": {
+        "href": "/api/v2/members/member333/mfa/request",
+        "type": "application/json"
+      }
+    },
+    "_id": "member333",
+    "firstName": "UserFirstName1",
+    "lastName": "UserLastName1",
+    "role": "writer",
+    "email": "UserFirstName1.UserLastName1@example.com",
+    "_pendingInvite": false,
+    "_verified": true,
+    "isBeta": false,
+    "customRoles": [],
+    "mfa": "disabled",
+    "excludedDashboards": [],
+    "_lastSeen": null,
+    "creationDate": 1748471259263,
+    "scimExternalId": "scimExternalId1",
+    "scimUsername": "UserFirstName1.UserLastName1@example.com",
+    "version": 25
+  }
+}

--- a/tests/fixtures/launchdarkly/audit_log_item_4.json
+++ b/tests/fixtures/launchdarkly/audit_log_item_4.json
@@ -9,7 +9,7 @@
       "type": "application/json"
     },
     "self": {
-      "href": "/api/v2/auditlog/abc444abc444aaa",
+      "href": "/api/v2/auditlog/abcd1111",
       "type": "application/json"
     },
     "site": {
@@ -17,9 +17,9 @@
       "type": "text/html"
     }
   },
-  "_id": "abc444abc444aaa",
-  "_accountId": "accountid444",
-  "date": 1755508937734,
+  "_id": "abcd1111",
+  "_accountId": "account-789ghi",
+  "date": 1755689827802,
   "accesses": [
     {
       "action": "deactivateScimMember",

--- a/tests/fixtures/launchdarkly/audit_log_item_4.json
+++ b/tests/fixtures/launchdarkly/audit_log_item_4.json
@@ -1,0 +1,107 @@
+{
+  "_links": {
+    "canonical": {
+      "href": "/api/v2/members/member444",
+      "type": "application/json"
+    },
+    "parent": {
+      "href": "/api/v2/auditlog",
+      "type": "application/json"
+    },
+    "self": {
+      "href": "/api/v2/auditlog/abc444abc444aaa",
+      "type": "application/json"
+    },
+    "site": {
+      "href": "/settings/members/member444/permissions",
+      "type": "text/html"
+    }
+  },
+  "_id": "abc444abc444aaa",
+  "_accountId": "accountid444",
+  "date": 1755508937734,
+  "accesses": [
+    {
+      "action": "deactivateScimMember",
+      "resource": "member/member444"
+    }
+  ],
+  "kind": "member",
+  "name": "UserFirstName UserLastName1",
+  "description": "* Deactivated the member\n",
+  "shortDescription": "",
+  "app": {
+    "_links": {
+      "external": {
+        "href": "https://www.okta.com/",
+        "type": "text/html"
+      },
+      "parent": {
+        "href": "/internal/account/oauth2/applications",
+        "type": "application/json"
+      },
+      "self": {
+        "href": "/internal/account/oauth2/applications/oath-uuid-1==",
+        "type": "application/json"
+      },
+      "site": {
+        "href": "/settings/authorization/oauth/oath-uuid-1==/review",
+        "type": "application/json"
+      }
+    },
+    "_id": "oath-uuid-1==",
+    "isScim": true,
+    "name": "Okta",
+    "maintainerName": "okta"
+  },
+  "titleVerb": "deactivated the member",
+  "title": "Deactivated the member [UserFirstName UserLastName1](https://app.launchdarkly.com/settings/members/member444/permissions) \\(via API\\)",
+  "target": {
+    "_links": {
+      "canonical": {
+        "href": "/api/v2/members/member444",
+        "type": "application/json"
+      },
+      "site": {
+        "href": "/settings/members/member444/permissions",
+        "type": "text/html"
+      }
+    },
+    "name": "UserFirstName UserLastName1",
+    "resources": [
+      "member/member444"
+    ]
+  },
+  "currentVersion": {
+    "_links": {
+      "parent": {
+        "href": "/api/v2/members",
+        "type": "application/json"
+      },
+      "self": {
+        "href": "/api/v2/members/member444",
+        "type": "application/json"
+      },
+      "sendMfaEnableRequest": {
+        "href": "/api/v2/members/member444/mfa/request",
+        "type": "application/json"
+      }
+    },
+    "_id": "member444",
+    "firstName": "UserFirstName1",
+    "lastName": "UserLastName1",
+    "role": "writer",
+    "email": "UserFirstName1.UserLastName1@example.com",
+    "_pendingInvite": false,
+    "_verified": true,
+    "isBeta": false,
+    "customRoles": [],
+    "mfa": "disabled",
+    "excludedDashboards": [],
+    "_lastSeen": null,
+    "creationDate": 1748471259263,
+    "scimExternalId": "scimExternalId1",
+    "scimUsername": "UserFirstName1.UserLastName1@example.com",
+    "version": 25
+  }
+}

--- a/tests/fixtures/launchdarkly/audit_log_item_5.json
+++ b/tests/fixtures/launchdarkly/audit_log_item_5.json
@@ -9,7 +9,7 @@
       "type": "application/json"
     },
     "self": {
-      "href": "/api/v2/auditlog/abc555abc555aaa",
+      "href": "/api/v2/auditlog/abcd2222",
       "type": "application/json"
     },
     "site": {
@@ -17,9 +17,9 @@
       "type": "text/html"
     }
   },
-  "_id": "abc555abc555aaa",
-  "_accountId": "accountid555",
-  "date": 1755508937735,
+  "_id": "abcd2222",
+  "_accountId": "account-789ghi",
+  "date": 1755676211704,
   "accesses": [
     {
       "action": "deactivateScimMember",

--- a/tests/fixtures/launchdarkly/audit_log_item_5.json
+++ b/tests/fixtures/launchdarkly/audit_log_item_5.json
@@ -1,0 +1,107 @@
+{
+  "_links": {
+    "canonical": {
+      "href": "/api/v2/members/member555",
+      "type": "application/json"
+    },
+    "parent": {
+      "href": "/api/v2/auditlog",
+      "type": "application/json"
+    },
+    "self": {
+      "href": "/api/v2/auditlog/abc555abc555aaa",
+      "type": "application/json"
+    },
+    "site": {
+      "href": "/settings/members/member555/permissions",
+      "type": "text/html"
+    }
+  },
+  "_id": "abc555abc555aaa",
+  "_accountId": "accountid555",
+  "date": 1755508937735,
+  "accesses": [
+    {
+      "action": "deactivateScimMember",
+      "resource": "member/member555"
+    }
+  ],
+  "kind": "member",
+  "name": "UserFirstName UserLastName1",
+  "description": "* Deactivated the member\n",
+  "shortDescription": "",
+  "app": {
+    "_links": {
+      "external": {
+        "href": "https://www.okta.com/",
+        "type": "text/html"
+      },
+      "parent": {
+        "href": "/internal/account/oauth2/applications",
+        "type": "application/json"
+      },
+      "self": {
+        "href": "/internal/account/oauth2/applications/oath-uuid-1==",
+        "type": "application/json"
+      },
+      "site": {
+        "href": "/settings/authorization/oauth/oath-uuid-1==/review",
+        "type": "application/json"
+      }
+    },
+    "_id": "oath-uuid-1==",
+    "isScim": true,
+    "name": "Okta",
+    "maintainerName": "okta"
+  },
+  "titleVerb": "deactivated the member",
+  "title": "Deactivated the member [UserFirstName UserLastName1](https://app.launchdarkly.com/settings/members/member555/permissions) \\(via API\\)",
+  "target": {
+    "_links": {
+      "canonical": {
+        "href": "/api/v2/members/member555",
+        "type": "application/json"
+      },
+      "site": {
+        "href": "/settings/members/member555/permissions",
+        "type": "text/html"
+      }
+    },
+    "name": "UserFirstName UserLastName1",
+    "resources": [
+      "member/member555"
+    ]
+  },
+  "currentVersion": {
+    "_links": {
+      "parent": {
+        "href": "/api/v2/members",
+        "type": "application/json"
+      },
+      "self": {
+        "href": "/api/v2/members/member555",
+        "type": "application/json"
+      },
+      "sendMfaEnableRequest": {
+        "href": "/api/v2/members/member555/mfa/request",
+        "type": "application/json"
+      }
+    },
+    "_id": "member555",
+    "firstName": "UserFirstName1",
+    "lastName": "UserLastName1",
+    "role": "writer",
+    "email": "UserFirstName1.UserLastName1@example.com",
+    "_pendingInvite": false,
+    "_verified": true,
+    "isBeta": false,
+    "customRoles": [],
+    "mfa": "disabled",
+    "excludedDashboards": [],
+    "_lastSeen": null,
+    "creationDate": 1748471259263,
+    "scimExternalId": "scimExternalId1",
+    "scimUsername": "UserFirstName1.UserLastName1@example.com",
+    "version": 25
+  }
+}

--- a/tests/fixtures/launchdarkly/audit_log_item_6.json
+++ b/tests/fixtures/launchdarkly/audit_log_item_6.json
@@ -1,0 +1,107 @@
+{
+  "_links": {
+    "canonical": {
+      "href": "/api/v2/members/member666",
+      "type": "application/json"
+    },
+    "parent": {
+      "href": "/api/v2/auditlog",
+      "type": "application/json"
+    },
+    "self": {
+      "href": "/api/v2/auditlog/abc666abc666aaa",
+      "type": "application/json"
+    },
+    "site": {
+      "href": "/settings/members/member666/permissions",
+      "type": "text/html"
+    }
+  },
+  "_id": "abc666abc666aaa",
+  "_accountId": "accountid666",
+  "date": 1755508937736,
+  "accesses": [
+    {
+      "action": "deactivateScimMember",
+      "resource": "member/member666"
+    }
+  ],
+  "kind": "member",
+  "name": "UserFirstName UserLastName1",
+  "description": "* Deactivated the member\n",
+  "shortDescription": "",
+  "app": {
+    "_links": {
+      "external": {
+        "href": "https://www.okta.com/",
+        "type": "text/html"
+      },
+      "parent": {
+        "href": "/internal/account/oauth2/applications",
+        "type": "application/json"
+      },
+      "self": {
+        "href": "/internal/account/oauth2/applications/oath-uuid-1==",
+        "type": "application/json"
+      },
+      "site": {
+        "href": "/settings/authorization/oauth/oath-uuid-1==/review",
+        "type": "application/json"
+      }
+    },
+    "_id": "oath-uuid-1==",
+    "isScim": true,
+    "name": "Okta",
+    "maintainerName": "okta"
+  },
+  "titleVerb": "deactivated the member",
+  "title": "Deactivated the member [UserFirstName UserLastName1](https://app.launchdarkly.com/settings/members/member666/permissions) \\(via API\\)",
+  "target": {
+    "_links": {
+      "canonical": {
+        "href": "/api/v2/members/member666",
+        "type": "application/json"
+      },
+      "site": {
+        "href": "/settings/members/member666/permissions",
+        "type": "text/html"
+      }
+    },
+    "name": "UserFirstName UserLastName1",
+    "resources": [
+      "member/member666"
+    ]
+  },
+  "currentVersion": {
+    "_links": {
+      "parent": {
+        "href": "/api/v2/members",
+        "type": "application/json"
+      },
+      "self": {
+        "href": "/api/v2/members/member666",
+        "type": "application/json"
+      },
+      "sendMfaEnableRequest": {
+        "href": "/api/v2/members/member666/mfa/request",
+        "type": "application/json"
+      }
+    },
+    "_id": "member666",
+    "firstName": "UserFirstName1",
+    "lastName": "UserLastName1",
+    "role": "writer",
+    "email": "UserFirstName1.UserLastName1@example.com",
+    "_pendingInvite": false,
+    "_verified": true,
+    "isBeta": false,
+    "customRoles": [],
+    "mfa": "disabled",
+    "excludedDashboards": [],
+    "_lastSeen": null,
+    "creationDate": 1748471259263,
+    "scimExternalId": "scimExternalId1",
+    "scimUsername": "UserFirstName1.UserLastName1@example.com",
+    "version": 25
+  }
+}

--- a/tests/fixtures/launchdarkly/audit_log_item_6.json
+++ b/tests/fixtures/launchdarkly/audit_log_item_6.json
@@ -17,9 +17,9 @@
       "type": "text/html"
     }
   },
-  "_id": "abc666abc666aaa",
-  "_accountId": "accountid666",
-  "date": 1755508937736,
+  "_id": "abcd3333",
+  "_accountId": "account-789ghi",
+  "date": 1755672865118,
   "accesses": [
     {
       "action": "deactivateScimMember",

--- a/tests/fixtures/launchdarkly/audit_log_list_1.json
+++ b/tests/fixtures/launchdarkly/audit_log_list_1.json
@@ -17,7 +17,7 @@
       },
       "_id": "entry-abc123",
       "_accountId": "account-def456",
-      "date": 1755529132466,
+      "date": 1755692329415,
       "accesses": [
         {
           "action": "updateIncluded",

--- a/tests/fixtures/launchdarkly/audit_log_list_1.json
+++ b/tests/fixtures/launchdarkly/audit_log_list_1.json
@@ -1,0 +1,205 @@
+{
+  "items": [
+    {
+      "_links": {
+        "parent": {
+          "href": "/api/v2/auditlog",
+          "type": "application/json"
+        },
+        "self": {
+          "href": "/api/v2/auditlog/entry-abc123",
+          "type": "application/json"
+        },
+        "site": {
+          "href": "/example-project/example-env/segments/example-segment-1",
+          "type": "text/html"
+        }
+      },
+      "_id": "entry-abc123",
+      "_accountId": "account-def456",
+      "date": 1755529132466,
+      "accesses": [
+        {
+          "action": "updateIncluded",
+          "resource": "proj/example-project:env/example-env:segment/example-segment-1;backend,frontend,organization"
+        }
+      ],
+      "kind": "segment",
+      "name": "example-segment-1",
+      "description": "* Added the included user [org-example123](https://app.launchdarkly.com/example-project/example-env/contexts/user/org-example123)\n",
+      "shortDescription": "",
+      "comment": "",
+      "member": {
+        "_links": {
+          "parent": {
+            "href": "/api/v2/members",
+            "type": "application/json"
+          },
+          "self": {
+            "href": "/api/v2/members/member-ghi789",
+            "type": "application/json"
+          }
+        },
+        "_id": "member-ghi789",
+        "email": "john.doe@example.com",
+        "firstName": "John",
+        "lastName": "Doe"
+      },
+      "titleVerb": "updated the segment",
+      "title": "[John Doe](mailto:john.doe@example.com) updated the segment [example-segment-1](https://app.launchdarkly.com/example-project/example-env/segments/example-segment-1)",
+      "target": {
+        "_links": {
+          "site": {
+            "href": "/example-project/example-env/segments/example-segment-1",
+            "type": "text/html"
+          }
+        },
+        "name": "example-segment-1",
+        "resources": [
+          "proj/example-project:env/example-env:segment/example-segment-1;backend,frontend,organization"
+        ]
+      }
+    },
+    {
+      "_links": {
+        "parent": {
+          "href": "/api/v2/auditlog",
+          "type": "application/json"
+        },
+        "self": {
+          "href": "/api/v2/auditlog/entry-jkl012",
+          "type": "application/json"
+        },
+        "site": {
+          "href": "/cloud-services/production/segments/example-segment-2",
+          "type": "text/html"
+        }
+      },
+      "_id": "entry-jkl012",
+      "_accountId": "account-def456",
+      "date": 1755527813362,
+      "accesses": [
+        {
+          "action": "updateRules",
+          "resource": "proj/cloud-services:env/production:segment/example-segment-2;hcp-vault"
+        }
+      ],
+      "kind": "segment",
+      "name": "Example Segment 2",
+      "description": "* Added the rule \n    > **If** `user` `organization_id` **is one of** `uuid120`  \n    **include** `all targets`\n    \n    \n",
+      "shortDescription": "",
+      "comment": "Add example user",
+      "member": {
+        "_links": {
+          "parent": {
+            "href": "/api/v2/members",
+            "type": "application/json"
+          },
+          "self": {
+            "href": "/api/v2/members/member-mno345",
+            "type": "application/json"
+          }
+        },
+        "_id": "member-mno345",
+        "email": "jane.smith@example.com",
+        "firstName": "Jane",
+        "lastName": "Smith"
+      },
+      "titleVerb": "updated the segment",
+      "title": "[Jane Smith](mailto:jane.smith@example.com) updated the segment [Example Segment 2](https://app.launchdarkly.com/cloud-services/production/segments/example-segment-2)",
+      "target": {
+        "_links": {
+          "site": {
+            "href": "/cloud-services/production/segments/example-segment-2",
+            "type": "text/html"
+          }
+        },
+        "name": "Example Segment 2",
+        "resources": [
+          "proj/cloud-services:env/production:segment/example-segment-2;hcp-vault"
+        ]
+      }
+    },
+    {
+      "_links": {
+        "canonical": {
+          "href": "/api/v2/members/member-pqr678",
+          "type": "application/json"
+        },
+        "parent": {
+          "href": "/api/v2/auditlog",
+          "type": "application/json"
+        },
+        "self": {
+          "href": "/api/v2/auditlog/entry-stu901",
+          "type": "application/json"
+        },
+        "site": {
+          "href": "/settings/members/member-pqr678/permissions",
+          "type": "text/html"
+        }
+      },
+      "_id": "entry-stu901",
+      "_accountId": "account-def456",
+      "date": 1755508937734,
+      "accesses": [
+        {
+          "action": "deactivateScimMember",
+          "resource": "member/member-pqr678"
+        }
+      ],
+      "kind": "member",
+      "name": "Alex Johnson",
+      "description": "* Deactivated the member\n",
+      "shortDescription": "",
+      "app": {
+        "_links": {
+          "external": {
+            "href": "https://www.exampleidp.com/",
+            "type": "text/html"
+          },
+          "parent": {
+            "href": "/internal/account/oauth2/applications",
+            "type": "application/json"
+          },
+          "self": {
+            "href": "/internal/account/oauth2/applications/oauth-app-789",
+            "type": "application/json"
+          },
+          "site": {
+            "href": "/settings/authorization/oauth/oauth-app-789/review",
+            "type": "application/json"
+          }
+        },
+        "_id": "oauth-app-789",
+        "isScim": true,
+        "name": "ExampleIDP",
+        "maintainerName": "exampleidp"
+      },
+      "titleVerb": "deactivated the member",
+      "title": "Deactivated the member [Alex Johnson](https://app.launchdarkly.com/settings/members/member-pqr678/permissions) \\(via API\\)",
+      "target": {
+        "_links": {
+          "canonical": {
+            "href": "/api/v2/members/member-pqr678",
+            "type": "application/json"
+          },
+          "site": {
+            "href": "/settings/members/member-pqr678/permissions",
+            "type": "text/html"
+          }
+        },
+        "name": "Alex Johnson",
+        "resources": [
+          "member/member-pqr678"
+        ]
+      }
+    }
+  ],
+  "_links": {
+    "self": {
+      "href": "/api/v2/auditlog?after=1755193754255&limit=3",
+      "type": "application/json"
+    }
+  }
+}

--- a/tests/fixtures/launchdarkly/audit_log_list_2.json
+++ b/tests/fixtures/launchdarkly/audit_log_list_2.json
@@ -1,0 +1,246 @@
+{
+  "items": [
+    {
+      "_links": {
+        "canonical": {
+          "href": "/api/v2/members/member-abc123",
+          "type": "application/json"
+        },
+        "parent": {
+          "href": "/api/v2/auditlog",
+          "type": "application/json"
+        },
+        "self": {
+          "href": "/api/v2/auditlog/entry-def456",
+          "type": "application/json"
+        },
+        "site": {
+          "href": "/settings/members/member-abc123/permissions",
+          "type": "text/html"
+        }
+      },
+      "_id": "entry-def456",
+      "_accountId": "account-789ghi",
+      "date": 1755495197934,
+      "accesses": [
+        {
+          "action": "deactivateScimMember",
+          "resource": "member/member-abc123"
+        }
+      ],
+      "kind": "member",
+      "name": "John Smith",
+      "description": "* Deactivated the member\n",
+      "shortDescription": "",
+      "app": {
+        "_links": {
+          "external": {
+            "href": "https://www.exampleidp.com/",
+            "type": "text/html"
+          },
+          "parent": {
+            "href": "/internal/account/oauth2/applications",
+            "type": "application/json"
+          },
+          "self": {
+            "href": "/internal/account/oauth2/applications/oauth-app-123",
+            "type": "application/json"
+          },
+          "site": {
+            "href": "/settings/authorization/oauth/oauth-app-123/review",
+            "type": "application/json"
+          }
+        },
+        "_id": "oauth-app-123",
+        "isScim": true,
+        "name": "ExampleIDP",
+        "maintainerName": "exampleidp"
+      },
+      "titleVerb": "deactivated the member",
+      "title": "Deactivated the member [John Smith](https://app.launchdarkly.com/settings/members/member-abc123/permissions) \\(via API\\)",
+      "target": {
+        "_links": {
+          "canonical": {
+            "href": "/api/v2/members/member-abc123",
+            "type": "application/json"
+          },
+          "site": {
+            "href": "/settings/members/member-abc123/permissions",
+            "type": "text/html"
+          }
+        },
+        "name": "John Smith",
+        "resources": [
+          "member/member-abc123"
+        ]
+      }
+    },
+    {
+      "_links": {
+        "canonical": {
+          "href": "/api/v2/flags/cloud-services/example-sso-disable-domain-ownership-check",
+          "type": "application/json"
+        },
+        "parent": {
+          "href": "/api/v2/auditlog",
+          "type": "application/json"
+        },
+        "self": {
+          "href": "/api/v2/auditlog/entry-jkl789",
+          "type": "application/json"
+        },
+        "site": {
+          "href": "/cloud-services/dev/features/example-sso-disable-domain-ownership-check",
+          "type": "text/html"
+        }
+      },
+      "_id": "entry-jkl789",
+      "_accountId": "account-789ghi",
+      "date": 1755493065170,
+      "accesses": [
+        {
+          "action": "updateRules",
+          "resource": "proj/cloud-services:env/dev:flag/example-sso-disable-domain-ownership-check"
+        }
+      ],
+      "kind": "flag",
+      "name": "Example SSO Disable Domain Ownership Check",
+      "description": "* Added `uuid120` to the rule \n    > **If** `user` `organization_id` **is one of** `uuid121`, `uuid122`, `uuid123`, `uuid120`  \n    **serve** `true`\n    \n    \n",
+      "shortDescription": "",
+      "comment": "",
+      "member": {
+        "_links": {
+          "parent": {
+            "href": "/api/v2/members",
+            "type": "application/json"
+          },
+          "self": {
+            "href": "/api/v2/members/member-mno456",
+            "type": "application/json"
+          }
+        },
+        "_id": "member-mno456",
+        "email": "jane.doe@example.com",
+        "firstName": "Jane",
+        "lastName": "Doe"
+      },
+      "titleVerb": "updated the flag",
+      "title": "[Jane Doe](mailto:jane.doe@example.com) updated the flag [Example SSO Disable Domain Ownership Check](https://app.launchdarkly.com/cloud-services/dev/features/example-sso-disable-domain-ownership-check) in `Development`",
+      "target": {
+        "_links": {
+          "canonical": {
+            "href": "/api/v2/flags/cloud-services/example-sso-disable-domain-ownership-check",
+            "type": "application/json"
+          },
+          "site": {
+            "href": "/cloud-services/dev/features/example-sso-disable-domain-ownership-check",
+            "type": "text/html"
+          }
+        },
+        "name": "Example SSO Disable Domain Ownership Check",
+        "resources": [
+          "proj/cloud-services:env/dev:flag/example-sso-disable-domain-ownership-check"
+        ]
+      },
+      "parent": {
+        "_links": {
+          "canonical": {
+            "href": "/api/v2/projects/cloud-services/environments/dev",
+            "type": "application/json"
+          },
+          "site": {
+            "href": "/settings/projects",
+            "type": "text/html"
+          }
+        },
+        "name": "Development",
+        "resource": "proj/cloud-services:env/dev"
+      }
+    },
+    {
+      "_links": {
+        "canonical": {
+          "href": "/api/v2/members/member-pqr789",
+          "type": "application/json"
+        },
+        "parent": {
+          "href": "/api/v2/auditlog",
+          "type": "application/json"
+        },
+        "self": {
+          "href": "/api/v2/auditlog/entry-stu012",
+          "type": "application/json"
+        },
+        "site": {
+          "href": "/settings/members/member-pqr789/permissions",
+          "type": "text/html"
+        }
+      },
+      "_id": "entry-stu012",
+      "_accountId": "account-789ghi",
+      "date": 1755331553385,
+      "accesses": [
+        {
+          "action": "deactivateScimMember",
+          "resource": "member/member-pqr789"
+        }
+      ],
+      "kind": "member",
+      "name": "Alex Johnson",
+      "description": "* Deactivated the member\n",
+      "shortDescription": "",
+      "app": {
+        "_links": {
+          "external": {
+            "href": "https://www.exampleidp.com/",
+            "type": "text/html"
+          },
+          "parent": {
+            "href": "/internal/account/oauth2/applications",
+            "type": "application/json"
+          },
+          "self": {
+            "href": "/internal/account/oauth2/applications/oauth-app-123",
+            "type": "application/json"
+          },
+          "site": {
+            "href": "/settings/authorization/oauth/oauth-app-123/review",
+            "type": "application/json"
+          }
+        },
+        "_id": "oauth-app-123",
+        "isScim": true,
+        "name": "ExampleIDP",
+        "maintainerName": "exampleidp"
+      },
+      "titleVerb": "deactivated the member",
+      "title": "Deactivated the member [Alex Johnson](https://app.launchdarkly.com/settings/members/member-pqr789/permissions) \\(via API\\)",
+      "target": {
+        "_links": {
+          "canonical": {
+            "href": "/api/v2/members/member-pqr789",
+            "type": "application/json"
+          },
+          "site": {
+            "href": "/settings/members/member-pqr789/permissions",
+            "type": "text/html"
+          }
+        },
+        "name": "Alex Johnson",
+        "resources": [
+          "member/member-pqr789"
+        ]
+      }
+    }
+  ],
+  "_links": {
+    "next": {
+      "href": "/api/v2/auditlog?after=1755193754255&before=1755331553385&limit=3",
+      "type": "application/json"
+    },
+    "self": {
+      "href": "/api/v2/auditlog?after=1755193754255&limit=3",
+      "type": "application/json"
+    }
+  }
+}

--- a/tests/fixtures/launchdarkly/audit_log_list_2.json
+++ b/tests/fixtures/launchdarkly/audit_log_list_2.json
@@ -21,7 +21,7 @@
       },
       "_id": "entry-def456",
       "_accountId": "account-789ghi",
-      "date": 1755495197934,
+      "date": 1755692329415,
       "accesses": [
         {
           "action": "deactivateScimMember",
@@ -96,7 +96,7 @@
       },
       "_id": "entry-jkl789",
       "_accountId": "account-789ghi",
-      "date": 1755493065170,
+      "date": 1755690378459,
       "accesses": [
         {
           "action": "updateRules",
@@ -178,7 +178,7 @@
       },
       "_id": "entry-stu012",
       "_accountId": "account-789ghi",
-      "date": 1755331553385,
+      "date": 1755690085032,
       "accesses": [
         {
           "action": "deactivateScimMember",

--- a/tests/fixtures/launchdarkly/audit_log_list_3.json
+++ b/tests/fixtures/launchdarkly/audit_log_list_3.json
@@ -1,0 +1,249 @@
+{
+  "items": [
+    {
+      "_links": {
+        "canonical": {
+          "href": "/api/v2/members/member-abc123",
+          "type": "application/json"
+        },
+        "parent": {
+          "href": "/api/v2/auditlog",
+          "type": "application/json"
+        },
+        "self": {
+          "href": "/api/v2/auditlog/abcd1111",
+          "type": "application/json"
+        },
+        "site": {
+          "href": "/settings/members/member-abc123/permissions",
+          "type": "text/html"
+        }
+      },
+      "_id": "abcd1111",
+      "_accountId": "account-789ghi",
+      "date": 1755305156337,
+      "accesses": [
+        {
+          "action": "activateScimMember",
+          "resource": "member/member-abc123"
+        }
+      ],
+      "kind": "member",
+      "name": "John Doe",
+      "description": "* Activated the member\n",
+      "shortDescription": "",
+      "app": {
+        "_links": {
+          "external": {
+            "href": "https://www.exampleidp.com/",
+            "type": "text/html"
+          },
+          "parent": {
+            "href": "/internal/account/oauth2/applications",
+            "type": "application/json"
+          },
+          "self": {
+            "href": "/internal/account/oauth2/applications/oauth-app-456",
+            "type": "application/json"
+          },
+          "site": {
+            "href": "/settings/authorization/oauth/oauth-app-456/review",
+            "type": "application/json"
+          }
+        },
+        "_id": "oauth-app-456",
+        "isScim": true,
+        "name": "ExampleIDP",
+        "maintainerName": "exampleidp"
+      },
+      "titleVerb": "activated the member",
+      "title": "Activated the member [John Doe](https://app.launchdarkly.com/settings/members/member-abc123/permissions) \\(via API\\)",
+      "target": {
+        "_links": {
+          "canonical": {
+            "href": "/api/v2/members/member-abc123",
+            "type": "application/json"
+          },
+          "site": {
+            "href": "/settings/members/member-abc123/permissions",
+            "type": "text/html"
+          }
+        },
+        "name": "John Doe",
+        "resources": [
+          "member/member-abc123"
+        ]
+      }
+    },
+    {
+      "_links": {
+        "canonical": {
+          "href": "/api/v2/flags/cloud-services/example-billing-check",
+          "type": "application/json"
+        },
+        "parent": {
+          "href": "/api/v2/auditlog",
+          "type": "application/json"
+        },
+        "self": {
+          "href": "/api/v2/auditlog/abcd2222",
+          "type": "application/json"
+        },
+        "site": {
+          "href": "/cloud-services/int/features/example-billing-check",
+          "type": "text/html"
+        }
+      },
+      "_id": "abcd2222",
+      "_accountId": "account-789ghi",
+      "date": 1755300123771,
+      "accesses": [
+        {
+          "action": "updateRules",
+          "resource": "proj/cloud-services:env/int:flag/example-billing-check"
+        }
+      ],
+      "kind": "flag",
+      "name": "example-billing-check",
+      "description": "* Changed the variation from ~~`true`~~ to `false` for the rule 'Example Test Account' \n    > **If** `user` `organization_id` **is one of** `uuid120`  \n    **serve** `false`\n    \n    \n",
+      "shortDescription": "",
+      "comment": "",
+      "member": {
+        "_links": {
+          "parent": {
+            "href": "/api/v2/members",
+            "type": "application/json"
+          },
+          "self": {
+            "href": "/api/v2/members/member-mno012",
+            "type": "application/json"
+          }
+        },
+        "_id": "member-mno012",
+        "email": "jane.smith@example.com",
+        "firstName": "Jane",
+        "lastName": "Smith"
+      },
+      "titleVerb": "updated the flag",
+      "title": "[Jane Smith](mailto:jane.smith@example.com) updated the flag [example-billing-check](https://app.launchdarkly.com/cloud-services/int/features/example-billing-check) in `Integration`",
+      "target": {
+        "_links": {
+          "canonical": {
+            "href": "/api/v2/flags/cloud-services/example-billing-check",
+            "type": "application/json"
+          },
+          "site": {
+            "href": "/cloud-services/int/features/example-billing-check",
+            "type": "text/html"
+          }
+        },
+        "name": "example-billing-check",
+        "resources": [
+          "proj/cloud-services:env/int:flag/example-billing-check"
+        ]
+      },
+      "parent": {
+        "_links": {
+          "canonical": {
+            "href": "/api/v2/projects/cloud-services/environments/int",
+            "type": "application/json"
+          },
+          "site": {
+            "href": "/settings/projects",
+            "type": "text/html"
+          }
+        },
+        "name": "Integration",
+        "resource": "proj/cloud-services:env/int"
+      }
+    },
+    {
+      "_links": {
+        "canonical": {
+          "href": "/api/v2/flags/cloud-services/example-api-gating",
+          "type": "application/json"
+        },
+        "parent": {
+          "href": "/api/v2/auditlog",
+          "type": "application/json"
+        },
+        "self": {
+          "href": "/api/v2/auditlog/abcd3333",
+          "type": "application/json"
+        },
+        "site": {
+          "href": "/cloud-services/int/features/example-api-gating",
+          "type": "text/html"
+        }
+      },
+      "_id": "abcd3333",
+      "_accountId": "account-789ghi",
+      "date": 1755300107719,
+      "accesses": [
+        {
+          "action": "updateRules",
+          "resource": "proj/cloud-services:env/int:flag/example-api-gating"
+        }
+      ],
+      "kind": "flag",
+      "name": "Example API Gating",
+      "description": "* Changed the variation from ~~`false`~~ to `true` for the rule 'Test Example Org' \n    > **If** `user` `organization_id` **is one of** `uuid120`  \n    **serve** `true`\n    \n    \n",
+      "shortDescription": "",
+      "comment": "",
+      "member": {
+        "_links": {
+          "parent": {
+            "href": "/api/v2/members",
+            "type": "application/json"
+          },
+          "self": {
+            "href": "/api/v2/members/member-mno012",
+            "type": "application/json"
+          }
+        },
+        "_id": "member-mno012",
+        "email": "jane.smith@example.com",
+        "firstName": "Jane",
+        "lastName": "Smith"
+      },
+      "titleVerb": "updated the flag",
+      "title": "[Jane Smith](mailto:jane.smith@example.com) updated the flag [Example API Gating](https://app.launchdarkly.com/cloud-services/int/features/example-api-gating) in `Integration`",
+      "target": {
+        "_links": {
+          "canonical": {
+            "href": "/api/v2/flags/cloud-services/example-api-gating",
+            "type": "application/json"
+          },
+          "site": {
+            "href": "/cloud-services/int/features/example-api-gating",
+            "type": "text/html"
+          }
+        },
+        "name": "Example API Gating",
+        "resources": [
+          "proj/cloud-services:env/int:flag/example-api-gating"
+        ]
+      },
+      "parent": {
+        "_links": {
+          "canonical": {
+            "href": "/api/v2/projects/cloud-services/environments/int",
+            "type": "application/json"
+          },
+          "site": {
+            "href": "/settings/projects",
+            "type": "text/html"
+          }
+        },
+        "name": "Integration",
+        "resource": "proj/cloud-services:env/int"
+      }
+    }
+  ],
+  "_links": {
+    "self": {
+      "href": "/api/v2/auditlog?after=1755193754255&before=1755331553385&limit=3",
+      "type": "application/json"
+    }
+  }
+}

--- a/tests/fixtures/launchdarkly/audit_log_list_3.json
+++ b/tests/fixtures/launchdarkly/audit_log_list_3.json
@@ -21,7 +21,7 @@
       },
       "_id": "abcd1111",
       "_accountId": "account-789ghi",
-      "date": 1755305156337,
+      "date": 1755689827802,
       "accesses": [
         {
           "action": "activateScimMember",
@@ -96,7 +96,7 @@
       },
       "_id": "abcd2222",
       "_accountId": "account-789ghi",
-      "date": 1755300123771,
+      "date": 1755676211704,
       "accesses": [
         {
           "action": "updateRules",
@@ -178,7 +178,7 @@
       },
       "_id": "abcd3333",
       "_accountId": "account-789ghi",
-      "date": 1755300107719,
+      "date": 1755672865118,
       "accesses": [
         {
           "action": "updateRules",

--- a/tests/test_connectors_launchdarkly_audit_records.py
+++ b/tests/test_connectors_launchdarkly_audit_records.py
@@ -126,7 +126,7 @@ class LaunchDarklyAuditTestCase(unittest.TestCase):
             content_type="application/json",
             body=bytes(
                 open(
-                    os.path.join(self.dir, "fixtures/launchdarkly/audit_log_item_3.json"),
+                    os.path.join(self.dir, "fixtures/launchdarkly/audit_log_item_1.json"),
                     "r",
                 ).read(),
                 "utf-8",
@@ -153,7 +153,7 @@ class LaunchDarklyAuditTestCase(unittest.TestCase):
             content_type="application/json",
             body=bytes(
                 open(
-                    os.path.join(self.dir, "fixtures/launchdarkly/audit_log_item_1.json"),
+                    os.path.join(self.dir, "fixtures/launchdarkly/audit_log_item_3.json"),
                     "r",
                 ).read(),
                 "utf-8",
@@ -166,7 +166,7 @@ class LaunchDarklyAuditTestCase(unittest.TestCase):
             content_type="application/json",
             body=bytes(
                 open(
-                    os.path.join(self.dir, "fixtures/launchdarkly/audit_log_item_6.json"),
+                    os.path.join(self.dir, "fixtures/launchdarkly/audit_log_item_4.json"),
                     "r",
                 ).read(),
                 "utf-8",
@@ -192,7 +192,7 @@ class LaunchDarklyAuditTestCase(unittest.TestCase):
             content_type="application/json",
             body=bytes(
                 open(
-                    os.path.join(self.dir, "fixtures/launchdarkly/audit_log_item_4.json"),
+                    os.path.join(self.dir, "fixtures/launchdarkly/audit_log_item_6.json"),
                     "r",
                 ).read(),
                 "utf-8",
@@ -203,7 +203,7 @@ class LaunchDarklyAuditTestCase(unittest.TestCase):
         # expected number of logs were returned.
         self.connector.run()
         self.assertEqual(self.connector._saved["logs"], 6)
-        self.assertEqual(self.connector.pointer, "1755508937736")
+        self.assertEqual(self.connector.pointer, "1755692329415")
 
     @responses.activate
     def test_collect_no_pagination(self):
@@ -229,7 +229,7 @@ class LaunchDarklyAuditTestCase(unittest.TestCase):
             content_type="application/json",
             body=bytes(
                 open(
-                    os.path.join(self.dir, "fixtures/launchdarkly/audit_log_item_6.json"),
+                    os.path.join(self.dir, "fixtures/launchdarkly/audit_log_item_4.json"),
                     "r",
                 ).read(),
                 "utf-8",
@@ -255,7 +255,7 @@ class LaunchDarklyAuditTestCase(unittest.TestCase):
             content_type="application/json",
             body=bytes(
                 open(
-                    os.path.join(self.dir, "fixtures/launchdarkly/audit_log_item_4.json"),
+                    os.path.join(self.dir, "fixtures/launchdarkly/audit_log_item_6.json"),
                     "r",
                 ).read(),
                 "utf-8",
@@ -265,4 +265,4 @@ class LaunchDarklyAuditTestCase(unittest.TestCase):
         # Set the chunk size large enough that no chunking is required.
         self.connector.run()
         self.assertEqual(self.connector._saved["logs"], 3)
-        self.assertEqual(self.connector.pointer, "1755508937736")
+        self.assertEqual(self.connector.pointer, "1755689827802")

--- a/tests/test_connectors_launchdarkly_audit_records.py
+++ b/tests/test_connectors_launchdarkly_audit_records.py
@@ -1,0 +1,268 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+"""Implements tests for the LaunchDarkly audit records collector."""
+
+import os
+import re
+import unittest
+from unittest.mock import patch
+
+import responses
+
+from grove.connectors.launchdarkly.audit_records import Connector
+from grove.models import ConnectorConfig
+from tests import mocks
+
+
+class LaunchDarklyAuditTestCase(unittest.TestCase):
+    """Implements tests for the LaunchDarkly audit records collector."""
+
+    @patch("grove.helpers.plugin.load_handler", mocks.load_handler)
+    def setUp(self):
+        """Ensure the application is setup for testing."""
+        self.dir = os.path.dirname(os.path.abspath(__file__))
+        self.connector = Connector(
+            config=ConnectorConfig(
+                identity="1FEEDFEED1",
+                key="token",
+                name="test",
+                connector="test",
+            ),
+            context={
+                "runtime": "test_harness",
+                "runtime_id": "NA",
+            },
+        )
+
+    @responses.activate
+    def test_collect_rate_limit(self):
+        """Ensure rate-limit retires are working as expected."""
+        # Rate limit the first request.
+        responses.add(
+            responses.GET,
+            re.compile(r"https://app.launchdarkly.com/api/v2/auditlog\?"),
+            status=429,
+            content_type="application/json",
+            body=bytes(),
+        )
+
+        # Succeed on the second.
+        responses.add(
+            responses.GET,
+            re.compile(r"https://app.launchdarkly.com/api/v2/auditlog\?"),
+            status=200,
+            content_type="application/json",
+            body=bytes(
+                open(
+                    os.path.join(self.dir, "fixtures/launchdarkly/audit_log_list_1.json"),
+                    "r",
+                ).read(),
+                "utf-8",
+            ),
+        )
+
+        # Include a generic secondary item query
+        responses.add(
+            responses.GET,
+            re.compile(r"https://app.launchdarkly.com/api/v2/auditlog/[a-z0-9-]+"),
+            status=200,
+            content_type="application/json",
+            body=bytes(
+                open(
+                    os.path.join(self.dir, "fixtures/launchdarkly/audit_log_item_1.json"),
+                    "r",
+                ).read(),
+                "utf-8",
+            ),
+        )
+
+        
+
+        # Ensure time.sleep is called with the correct value in response to a
+        # rate-limit.
+        with patch("time.sleep", return_value=None) as mock_sleep:
+            self.connector.run()
+            mock_sleep.assert_called_with(1)
+
+    @responses.activate
+    def test_collect_pagination(self):
+        """Ensure pagination is working as expected."""
+        # Succeed with a cursor returned (to indicate paging is required).
+        responses.add(
+            responses.GET,
+            re.compile(r"https://app.launchdarkly.com/api/v2/auditlog\?after=[0-9]+&limit=[0-9]+"),
+            status=200,
+            content_type="application/json",
+            body=bytes(
+                open(
+                    os.path.join(self.dir, "fixtures/launchdarkly/audit_log_list_2.json"),
+                    "r",
+                ).read(),
+                "utf-8",
+            ),
+        )
+
+        # The last "page" returns an empty cursor.
+        responses.add(
+            responses.GET,
+            re.compile(r"https://app.launchdarkly.com/api/v2/auditlog\?after=[0-9]+&before=[0-9]+&limit=[0-9]+"),
+            status=200,
+            content_type="application/json",
+            body=bytes(
+                open(
+                    os.path.join(self.dir, "fixtures/launchdarkly/audit_log_list_3.json"),
+                    "r",
+                ).read(),
+                "utf-8",
+            ),
+        )
+
+        # Include item queries
+        responses.add(
+            responses.GET,
+            re.compile(r"https://app.launchdarkly.com/api/v2/auditlog/entry-def456"),
+            status=200,
+            content_type="application/json",
+            body=bytes(
+                open(
+                    os.path.join(self.dir, "fixtures/launchdarkly/audit_log_item_3.json"),
+                    "r",
+                ).read(),
+                "utf-8",
+            ),
+        )
+
+        responses.add(
+            responses.GET,
+            re.compile(r"https://app.launchdarkly.com/api/v2/auditlog/entry-jkl789"),
+            status=200,
+            content_type="application/json",
+            body=bytes(
+                open(
+                    os.path.join(self.dir, "fixtures/launchdarkly/audit_log_item_2.json"),
+                    "r",
+                ).read(),
+                "utf-8",
+                ),
+        )
+        responses.add(
+            responses.GET,
+            re.compile(r"https://app.launchdarkly.com/api/v2/auditlog/entry-stu012"),
+            status=200,
+            content_type="application/json",
+            body=bytes(
+                open(
+                    os.path.join(self.dir, "fixtures/launchdarkly/audit_log_item_1.json"),
+                    "r",
+                ).read(),
+                "utf-8",
+            ),
+        )
+        responses.add(
+            responses.GET,
+            re.compile(r"https://app.launchdarkly.com/api/v2/auditlog/abcd1111"),
+            status=200,
+            content_type="application/json",
+            body=bytes(
+                open(
+                    os.path.join(self.dir, "fixtures/launchdarkly/audit_log_item_6.json"),
+                    "r",
+                ).read(),
+                "utf-8",
+            ),
+        )
+        responses.add(
+            responses.GET,
+            re.compile(r"https://app.launchdarkly.com/api/v2/auditlog/abcd2222"),
+            status=200,
+            content_type="application/json",
+            body=bytes(
+                open(
+                    os.path.join(self.dir, "fixtures/launchdarkly/audit_log_item_5.json"),
+                    "r",
+                ).read(),
+                "utf-8",
+            ),
+        )
+        responses.add(
+            responses.GET,
+            re.compile(r"https://app.launchdarkly.com/api/v2/auditlog/abcd3333"),
+            status=200,
+            content_type="application/json",
+            body=bytes(
+                open(
+                    os.path.join(self.dir, "fixtures/launchdarkly/audit_log_item_4.json"),
+                    "r",
+                ).read(),
+                "utf-8",
+            ),
+        )
+
+        # Check the pointer matches the latest execution_time value, and that the
+        # expected number of logs were returned.
+        self.connector.run()
+        self.assertEqual(self.connector._saved["logs"], 6)
+        self.assertEqual(self.connector.pointer, "1755508937736")
+
+    @responses.activate
+    def test_collect_no_pagination(self):
+        """Ensure collection without pagination is working as expected."""
+        responses.add(
+            responses.GET,
+            re.compile(r"https://app.launchdarkly.com/api/v2/auditlog\?"),
+            status=200,
+            content_type="application/json",
+            body=bytes(
+                open(
+                    os.path.join(self.dir, "fixtures/launchdarkly/audit_log_list_3.json"),
+                    "r",
+                ).read(),
+                "utf-8",
+            ),
+        )
+
+        responses.add(
+            responses.GET,
+            re.compile(r"https://app.launchdarkly.com/api/v2/auditlog/abcd1111"),
+            status=200,
+            content_type="application/json",
+            body=bytes(
+                open(
+                    os.path.join(self.dir, "fixtures/launchdarkly/audit_log_item_6.json"),
+                    "r",
+                ).read(),
+                "utf-8",
+            ),
+        )
+        responses.add(
+            responses.GET,
+            re.compile(r"https://app.launchdarkly.com/api/v2/auditlog/abcd2222"),
+            status=200,
+            content_type="application/json",
+            body=bytes(
+                open(
+                    os.path.join(self.dir, "fixtures/launchdarkly/audit_log_item_5.json"),
+                    "r",
+                ).read(),
+                "utf-8",
+            ),
+        )
+        responses.add(
+            responses.GET,
+            re.compile(r"https://app.launchdarkly.com/api/v2/auditlog/abcd3333"),
+            status=200,
+            content_type="application/json",
+            body=bytes(
+                open(
+                    os.path.join(self.dir, "fixtures/launchdarkly/audit_log_item_4.json"),
+                    "r",
+                ).read(),
+                "utf-8",
+            ),
+        )
+
+        # Set the chunk size large enough that no chunking is required.
+        self.connector.run()
+        self.assertEqual(self.connector._saved["logs"], 3)
+        self.assertEqual(self.connector.pointer, "1755508937736")


### PR DESCRIPTION
Creating a LaunchDarkly Audit Log connector.

The connector first pulls the list of audit log entries from the API endpoint 
https://launchdarkly.com/docs/api/audit-log/get-audit-log-entries

After, it iterates through the IDs of the entries and returns the more detailied information about each entry using the API endpoint
https://launchdarkly.com/docs/api/audit-log/get-audit-log-entry