### PR TITLE
Launchdarkly Connector Verbose Mode

### DIFF
--- a/grove/connectors/launchdarkly/api.py
+++ b/grove/connectors/launchdarkly/api.py
@@ -86,7 +86,7 @@ class Client:
         limit: Optional[str] = None,
         q: Optional[str] = None,
         spec: Optional[str] = None,
-        verbose: Optional[str] = "false"
+        verbose: bool = False
     ) -> AuditLogEntries:
         """Fetches a list of audit logs which match the provided filters.
 
@@ -121,8 +121,7 @@ class Client:
         # Record the cursor, if set.
         cursor = result.body.get("_links", {}).get("next", {}).get("href")
 
-        v = str.lower(verbose) if verbose is not None else "false"
-        if(v == "true"):
+        if(verbose):
 
             # Pull the list of ids out of the returned results list
             ids = search("items[*]._id", result.body)

--- a/grove/connectors/launchdarkly/audit_records.py
+++ b/grove/connectors/launchdarkly/audit_records.py
@@ -9,7 +9,7 @@ from typing import Optional
 from grove.connectors import BaseConnector
 from grove.connectors.launchdarkly.api import Client
 from grove.constants import REVERSE_CHRONOLOGICAL
-from grove.exceptions import NotFoundException
+from grove.exceptions import ConfigurationException, NotFoundException
 
 
 class Connector(BaseConnector):
@@ -18,15 +18,17 @@ class Connector(BaseConnector):
     LOG_ORDER = REVERSE_CHRONOLOGICAL
 
     @property
-    def verbose(self) -> str:
+    def verbose(self) -> bool:
         """Fetches the verbose option from the configuration.
 
         :return: The "verbose" portion of the connector's configuration.
         """
         try:
-            return self.configuration.verbose
+            if not isinstance(self.configuration.verbose, bool):
+                raise ConfigurationException("If set, verbose configuration option must be a boolean")
         except AttributeError:
-            return "False"
+                return False
+        return self.configuration.verbose
 
     def collect(self):
         """Collects launchdarkly audit records from the launchdarkly API.

--- a/templates/configuration/launchdarkly/audit_records.json
+++ b/templates/configuration/launchdarkly/audit_records.json
@@ -3,5 +3,5 @@
     "identity": "ORGANIZATION_ID",
     "name": "launchdarkly-audit-records-example",
     "connector": "launchdarkly_audit_records",
-    "verbose": "false"
+    "verbose": false
 }

--- a/tests/test_connectors_launchdarkly_audit_records.py
+++ b/tests/test_connectors_launchdarkly_audit_records.py
@@ -28,7 +28,7 @@ class LaunchDarklyAuditTestCase(unittest.TestCase):
                 key="token",
                 name="test",
                 connector="test",
-                verbose="false"
+                verbose=False
             ),
             context={
                 "runtime": "test_harness",

--- a/tests/test_connectors_launchdarkly_audit_records_verbose.py
+++ b/tests/test_connectors_launchdarkly_audit_records_verbose.py
@@ -28,7 +28,7 @@ class LaunchDarklyAuditTestCase(unittest.TestCase):
                 key="token",
                 name="test",
                 connector="test",
-                verbose="true"
+                verbose=True
             ),
             context={
                 "runtime": "test_harness",


### PR DESCRIPTION
The initial version of the LaunchDarkly connector went through and got the detailed log information for each audit log. The size of some of those logs ended up overloading the SumoLogic FER parsing, even if they do potentially have useful data.

In order to have the option to have the summary view of the audit logs for alerting and also the detailed view for archival or investigation, I added a `verbose` flag in the configuration that toggles which type of logs should be returned without needing to build a second connector for mostly the same results.