### PR TITLE
Fix klaviyo references in test files

### DIFF
--- a/grove/connectors/sf/event_log.py
+++ b/grove/connectors/sf/event_log.py
@@ -120,7 +120,7 @@ class Connector(BaseConnector):
             return SF_OAUTH_TOKEN_URL_DEFAULT
 
         # Extract the base domain from the instance URL and construct OAuth endpoint
-        # e.g., https://klaviyo.my.salesforce.com -> https://klaviyo.my.salesforce.com/services/oauth2/token
+        # e.g., https://testorg.my.salesforce.com -> https://testorg.my.salesforce.com/services/oauth2/token
         instance_url = self.instance_url.rstrip("/")
         oauth_url = f"{instance_url}/services/oauth2/token"
 

--- a/tests/test_connectors_sf_event_log.py
+++ b/tests/test_connectors_sf_event_log.py
@@ -387,7 +387,7 @@ class SFEventLogTestCase(unittest.TestCase):
                 client_id="test_client_id",
                 client_secret="test_client_secret",
                 identity="test@example.com",
-                instance_url="https://klaviyo.my.salesforce.com",
+                instance_url="https://testorg.my.salesforce.com",
                 name="test-custom",
                 connector="sf_event_log",
                 operation="Login",
@@ -396,7 +396,7 @@ class SFEventLogTestCase(unittest.TestCase):
         )
         
         # Should use instance-specific OAuth endpoint
-        self.assertEqual(custom_connector._get_oauth_token_url(), "https://klaviyo.my.salesforce.com/services/oauth2/token")
+        self.assertEqual(custom_connector._get_oauth_token_url(), "https://testorg.my.salesforce.com/services/oauth2/token")
         
         # Test sandbox URL selection
         sandbox_connector = Connector(


### PR DESCRIPTION
## Summary
Replaces klaviyo.salesforce.com references with testorg.my.salesforce.com in test files and comments to ensure all test data uses obviously fake values.

## Changes
- Updated comment example in `grove/connectors/sf/event_log.py`
- Replaced klaviyo references in `tests/test_connectors_sf_event_log.py` test cases
- All test data now uses `testorg.my.salesforce.com` instead of `klaviyo.my.salesforce.com`

## Files Modified
- `grove/connectors/sf/event_log.py` - Updated comment example
- `tests/test_connectors_sf_event_log.py` - Updated test instance URLs and assertions