### PR TITLE
outputs: add Kafka output handler

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -166,3 +166,116 @@ returned from SSM would then be used in place of the field named :code:`key`.
 The use of a secrets backend allows sensitive information to be removed from
 configuration documents, allowing configuration documents to be stored directly on disk,
 or in other less sensitive backends where non-administrative users may have read-access.
+
+Output Handlers
+===============
+
+Grove supports pluggable output handlers that control where collected log data is
+written or published. The output handler is selected by setting the :code:`GROVE_OUTPUT`
+environment variable to the name of the desired handler.
+
+Kafka
+-----
+
+The :code:`kafka` output handler publishes collected log data to an Apache Kafka topic
+or Confluent Platform cluster. Each Grove batch may produce one or more Kafka messages
+depending on the number of records and the configured size thresholds.
+
+.. note::
+   The Kafka output handler requires an additional dependency. Install it with:
+
+   .. code-block:: shell
+
+      pip install grove[kafka]
+
+Required configuration
+~~~~~~~~~~~~~~~~~~~~~~
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 60
+
+   * - Environment Variable
+     - Description
+   * - :code:`GROVE_OUTPUT_KAFKA_BOOTSTRAP_SERVERS`
+     - Comma-separated list of Kafka broker addresses (:code:`host:port`).
+   * - :code:`GROVE_OUTPUT_KAFKA_TOPIC`
+     - Default Kafka topic to publish log data to. Connectors that set a
+       :code:`descriptor` will override this value on a per-batch basis.
+
+Optional configuration
+~~~~~~~~~~~~~~~~~~~~~~
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 20 40
+
+   * - Environment Variable
+     - Default
+     - Description
+   * - :code:`GROVE_OUTPUT_KAFKA_SECURITY_PROTOCOL`
+     - :code:`PLAINTEXT`
+     - Protocol used to communicate with brokers (:code:`PLAINTEXT`,
+       :code:`SSL`, :code:`SASL_PLAINTEXT`, :code:`SASL_SSL`).
+   * - :code:`GROVE_OUTPUT_KAFKA_SASL_MECHANISM`
+     - *(unset)*
+     - SASL mechanism for authentication (:code:`PLAIN`, :code:`SCRAM-SHA-256`,
+       :code:`OAUTHBEARER`, etc.).
+   * - :code:`GROVE_OUTPUT_KAFKA_SASL_USERNAME`
+     - *(unset)*
+     - SASL username for broker authentication.
+   * - :code:`GROVE_OUTPUT_KAFKA_SASL_PASSWORD`
+     - *(unset)*
+     - SASL password for broker authentication.
+   * - :code:`GROVE_OUTPUT_KAFKA_SSL_CA_LOCATION`
+     - *(unset)*
+     - Path to a CA certificate file for TLS verification.
+   * - :code:`GROVE_OUTPUT_KAFKA_SSL_CERTIFICATE_LOCATION`
+     - *(unset)*
+     - Path to a client certificate file for mutual TLS.
+   * - :code:`GROVE_OUTPUT_KAFKA_SSL_KEY_LOCATION`
+     - *(unset)*
+     - Path to a client private key file for mutual TLS.
+   * - :code:`GROVE_OUTPUT_KAFKA_MAX_RECORDS_PER_MESSAGE`
+     - :code:`500`
+     - Maximum number of log records per Kafka message.
+   * - :code:`GROVE_OUTPUT_KAFKA_MAX_BYTES_PER_MESSAGE`
+     - :code:`750000`
+     - Maximum serialized payload size in bytes per Kafka message. This is
+       intentionally conservative relative to the Kafka default of 1 MiB
+       to allow headroom for message headers.
+   * - :code:`GROVE_OUTPUT_KAFKA_COMPRESSION_TYPE`
+     - :code:`lz4`
+     - Compression codec applied by the producer (:code:`none`, :code:`gzip`,
+       :code:`snappy`, :code:`lz4`, :code:`zstd`).
+   * - :code:`GROVE_OUTPUT_KAFKA_FLUSH_TIMEOUT`
+     - :code:`30`
+     - Seconds to wait for delivery confirmation before raising an error.
+   * - :code:`GROVE_OUTPUT_KAFKA_USE_IDENTITY_AS_KEY`
+     - :code:`false`
+     - When :code:`true`, the connector identity is used as the Kafka message
+       key. This ensures all records from the same identity are routed to the
+       same partition.
+
+Examples
+~~~~~~~~
+
+Publishing to a local Kafka cluster over plaintext:
+
+.. code-block:: shell
+
+   GROVE_OUTPUT=kafka
+   GROVE_OUTPUT_KAFKA_BOOTSTRAP_SERVERS=kafka.internal:9092
+   GROVE_OUTPUT_KAFKA_TOPIC=grove-logs
+
+Publishing to Confluent Cloud with SASL_SSL authentication:
+
+.. code-block:: shell
+
+   GROVE_OUTPUT=kafka
+   GROVE_OUTPUT_KAFKA_BOOTSTRAP_SERVERS=pkc-xxxxx.us-east-1.aws.confluent.cloud:9092
+   GROVE_OUTPUT_KAFKA_TOPIC=grove-logs
+   GROVE_OUTPUT_KAFKA_SECURITY_PROTOCOL=SASL_SSL
+   GROVE_OUTPUT_KAFKA_SASL_MECHANISM=PLAIN
+   GROVE_OUTPUT_KAFKA_SASL_USERNAME=<API_KEY>
+   GROVE_OUTPUT_KAFKA_SASL_PASSWORD=<API_SECRET>

--- a/grove/outputs/kafka.py
+++ b/grove/outputs/kafka.py
@@ -1,0 +1,291 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+"""Grove Kafka output handler."""
+
+import json
+from typing import Any, Dict, List, Optional
+
+from pydantic import Field
+
+from grove.constants import GROVE_METADATA_KEY
+from grove.exceptions import AccessException, ConfigurationException, DataFormatException
+from grove.outputs import BaseOutput
+
+
+class Handler(BaseOutput):
+    """Output handler to publish Grove logs to Apache Kafka or Confluent Platform."""
+
+    class Configuration(BaseOutput.Configuration):
+        """Defines environment variables used to configure the Kafka handler.
+
+        This should also include any appropriate default values for fields which are not
+        required.
+        """
+
+        bootstrap_servers: str = Field(
+            description="Comma-separated list of Kafka broker addresses (host:port).",
+        )
+        topic: str = Field(
+            description="Default Kafka topic to publish log data to.",
+        )
+        security_protocol: str = Field(
+            description="Protocol used to communicate with Kafka brokers.",
+            default="PLAINTEXT",
+        )
+        sasl_mechanism: Optional[str] = Field(
+            description=(
+                "SASL mechanism for authentication (e.g. PLAIN, SCRAM-SHA-256, "
+                "OAUTHBEARER)."
+            ),
+            default=None,
+        )
+        sasl_username: Optional[str] = Field(
+            description="SASL username for broker authentication.",
+            default=None,
+        )
+        sasl_password: Optional[str] = Field(
+            description="SASL password for broker authentication.",
+            default=None,
+        )
+        ssl_ca_location: Optional[str] = Field(
+            description="Path to a CA certificate file for TLS verification.",
+            default=None,
+        )
+        ssl_certificate_location: Optional[str] = Field(
+            description="Path to a client certificate file for mutual TLS.",
+            default=None,
+        )
+        ssl_key_location: Optional[str] = Field(
+            description="Path to a client private key file for mutual TLS.",
+            default=None,
+        )
+        max_records_per_message: int = Field(
+            description="Maximum number of log records per Kafka message.",
+            default=500,
+        )
+        max_bytes_per_message: int = Field(
+            description="Maximum serialized size in bytes per Kafka message.",
+            default=750000,
+        )
+        compression_type: str = Field(
+            description=(
+                "Compression codec applied by the Kafka producer "
+                "(none, gzip, snappy, lz4, zstd)."
+            ),
+            default="lz4",
+        )
+        flush_timeout: int = Field(
+            description=(
+                "Seconds to wait for delivery confirmation before raising an error."
+            ),
+            default=30,
+        )
+        use_identity_as_key: bool = Field(
+            description="Whether to use the connector identity as the Kafka message key.",
+            default=False,
+        )
+
+        class Config:
+            """Allow environment variable override of configuration fields.
+
+            This also enforces a prefix for all environment variables for this handler.
+            As an example the field `bootstrap_servers` would be set using the
+            environment variable `GROVE_OUTPUT_KAFKA_BOOTSTRAP_SERVERS`.
+            """
+
+            env_prefix = "GROVE_OUTPUT_KAFKA_"
+            case_insensitive = True
+
+    def setup(self):
+        """Instantiates the Kafka producer using the resolved configuration.
+
+        :raises ConfigurationException: The confluent-kafka package is not installed,
+            or the producer could not be created with the supplied configuration.
+        """
+        try:
+            from confluent_kafka import BufferError as KafkaBufferError  # type: ignore
+            from confluent_kafka import Producer  # type: ignore
+        except ImportError:
+            raise ConfigurationException(
+                "The confluent-kafka package is required for the Kafka output handler. "
+                "Install it with: pip install grove[kafka]"
+            )
+
+        # Store for use in _produce_chunk without re-importing.
+        self._KafkaBufferError = KafkaBufferError
+
+        conf: Dict[str, Any] = {
+            "bootstrap.servers": self.config.bootstrap_servers,
+            "security.protocol": self.config.security_protocol,
+            "compression.type": self.config.compression_type,
+        }
+
+        if self.config.sasl_mechanism:
+            conf["sasl.mechanism"] = self.config.sasl_mechanism
+        if self.config.sasl_username:
+            conf["sasl.username"] = self.config.sasl_username
+        if self.config.sasl_password:
+            conf["sasl.password"] = self.config.sasl_password
+        if self.config.ssl_ca_location:
+            conf["ssl.ca.location"] = self.config.ssl_ca_location
+        if self.config.ssl_certificate_location:
+            conf["ssl.certificate.location"] = self.config.ssl_certificate_location
+        if self.config.ssl_key_location:
+            conf["ssl.key.location"] = self.config.ssl_key_location
+
+        try:
+            self._producer = Producer(conf)
+        except Exception as err:
+            raise ConfigurationException(f"Failed to create Kafka producer: {err}")
+
+    def _on_delivery(self, err: Any, msg: Any):
+        """Records delivery errors reported by the Kafka producer.
+
+        :param err: A KafkaError instance if delivery failed, or None on success.
+        :param msg: The delivered Message object.
+        """
+        if err is not None:
+            self._delivery_errors.append(str(err))
+
+    def _produce_chunk(self, topic: str, value: bytes, key: Optional[bytes]):
+        """Produces a single message chunk to Kafka, flushing on buffer overflow.
+
+        :param topic: Kafka topic to produce to.
+        :param value: Serialized message payload.
+        :param key: Optional message key bytes.
+
+        :raises AccessException: A non-recoverable producer error occurred.
+        """
+        try:
+            self._producer.produce(
+                topic,
+                value=value,
+                key=key,
+                on_delivery=self._on_delivery,
+            )
+            self._producer.poll(0)
+        except self._KafkaBufferError:
+            # Internal queue is full; flush outstanding messages then retry once.
+            self._producer.flush(self.config.flush_timeout)
+            self._producer.produce(
+                topic,
+                value=value,
+                key=key,
+                on_delivery=self._on_delivery,
+            )
+            self._producer.poll(0)
+        except Exception as err:
+            raise AccessException(f"Failed to produce Kafka message: {err}")
+
+    def submit(
+        self,
+        data: bytes,
+        connector: str,
+        identity: str,
+        operation: str,
+        part: int = 0,
+        suffix: Optional[str] = None,
+        descriptor: Optional[str] = None,
+        name: Optional[str] = None,
+    ):
+        """Publishes collected log data to a Kafka topic as NDJSON messages.
+
+        Each call to submit may produce one or more Kafka messages depending on the
+        number of log records and the configured byte and record thresholds.
+
+        :param data: Log data to publish (plain NDJSON bytes as returned by serialize).
+        :param connector: Name of the connector which retrieved the data.
+        :param identity: Identity the collected data was collected for.
+        :param operation: Operation the collected logs are associated with.
+        :param part: Number indicating which part of the same log stream this data
+            contains logs for.
+        :param suffix: Currently not used by this output handler.
+        :param descriptor: Optional topic name override. When provided, log data is
+            published to this topic instead of the configured default topic.
+        :param name: Given name of the connector as specified in the user's configuration.
+
+        :raises AccessException: A message could not be delivered to the broker.
+        """
+        topic = descriptor if descriptor else self.config.topic
+        key: Optional[bytes] = (
+            bytes(identity, "utf-8") if self.config.use_identity_as_key else None
+        )
+
+        # Reset delivery errors for this submit call.
+        self._delivery_errors: List[str] = []
+
+        # Split NDJSON payload into individual record lines.
+        lines = [line for line in data.split(b"\r\n") if line]
+
+        # Chunk lines by max_records_per_message and max_bytes_per_message.
+        chunk: List[bytes] = []
+        chunk_bytes = 0
+
+        for line in lines:
+            line_size = len(line) + 2  # +2 accounts for the \r\n separator
+
+            # Flush current chunk if adding this line would exceed either threshold.
+            if chunk and (
+                len(chunk) >= self.config.max_records_per_message
+                or chunk_bytes + line_size > self.config.max_bytes_per_message
+            ):
+                self._produce_chunk(topic, b"\r\n".join(chunk), key)
+                chunk = []
+                chunk_bytes = 0
+
+            chunk.append(line)
+            chunk_bytes += line_size
+
+        # Produce the final (possibly partial) chunk.
+        if chunk:
+            self._produce_chunk(topic, b"\r\n".join(chunk), key)
+
+        # Wait for all in-flight messages to be delivered.
+        remaining = self._producer.flush(self.config.flush_timeout)
+        if remaining > 0:
+            raise AccessException(
+                f"Kafka flush timed out with {remaining} message(s) still undelivered."
+            )
+
+        if self._delivery_errors:
+            errors = "; ".join(self._delivery_errors)
+            raise AccessException(
+                f"One or more Kafka messages failed delivery: {errors}"
+            )
+
+    def serialize(self, data: List[Any], metadata: Dict[str, Any] = {}) -> bytes:
+        """Implements serialization of log entries to plain NDJSON.
+
+        Compression is delegated to the Kafka producer via the configured
+        compression_type, so the payload returned here is not compressed.
+
+        :param data: A list of log entries to serialize to JSON.
+        :param metadata: Metadata to append to each log entry before serialization. If
+            not specified no metadata will be added.
+
+        :return: Log data serialized as NDJSON (as bytes).
+
+        :raises DataFormatException: Cannot serialize the input to JSON.
+        """
+        candidate = []
+
+        for entry in data:
+            # Skip empty log entries.
+            if entry is None:
+                continue
+
+            if metadata:
+                entry[GROVE_METADATA_KEY] = {
+                    **metadata,
+                    **entry.get(GROVE_METADATA_KEY, {}),
+                }
+
+            # We don't want to silently drop and lose single records, so drop the entire
+            # batch if there is bad data (which will trigger a retry next run).
+            try:
+                candidate.append(json.dumps(entry, separators=(",", ":"), default=str))
+            except TypeError as err:
+                raise DataFormatException(f"Unable to serialize to JSON: {err}")
+
+        return bytes("\r\n".join(candidate), "utf-8")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,9 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+kafka = [
+    "confluent-kafka>=2.0.0,<3.0",
+]
 tests = [
     "black",
     "coverage",
@@ -117,6 +120,7 @@ local_file = "grove.caches.local_file:Handler"
 
 [project.entry-points."grove.outputs"]
 aws_s3 = "grove.outputs.aws_s3:Handler"
+kafka = "grove.outputs.kafka:Handler"
 local_file = "grove.outputs.local_file:Handler"
 local_stdout = "grove.outputs.local_stdout:Handler"
 remote_http = "grove.outputs.remote_http:Handler"

--- a/tests/test_outputs_kafka.py
+++ b/tests/test_outputs_kafka.py
@@ -1,0 +1,261 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+"""Implements tests for the Kafka output handler."""
+
+import os
+import sys
+import unittest
+from unittest.mock import MagicMock
+
+# Provide a mock confluent_kafka module before the handler is imported, since it is an
+# optional dependency and may not be installed in the test environment.
+_mock_confluent_kafka = MagicMock()
+_mock_confluent_kafka.BufferError = type("BufferError", (Exception,), {})
+sys.modules["confluent_kafka"] = _mock_confluent_kafka
+
+from grove.exceptions import AccessException, ConfigurationException  # noqa: E402
+from grove.outputs.kafka import Handler  # noqa: E402
+
+
+class KafkaOutputTestCase(unittest.TestCase):
+    """Implements tests for the Kafka output handler."""
+
+    def setUp(self):
+        os.environ["GROVE_OUTPUT_KAFKA_BOOTSTRAP_SERVERS"] = "localhost:9092"
+        os.environ["GROVE_OUTPUT_KAFKA_TOPIC"] = "grove-logs"
+
+        self.mock_producer = MagicMock()
+        self.mock_producer.flush.return_value = 0
+        _mock_confluent_kafka.Producer.return_value = self.mock_producer
+
+        self.handler = Handler()
+        self.handler.setup()
+
+    def tearDown(self):
+        for key in [
+            "GROVE_OUTPUT_KAFKA_BOOTSTRAP_SERVERS",
+            "GROVE_OUTPUT_KAFKA_TOPIC",
+            "GROVE_OUTPUT_KAFKA_SECURITY_PROTOCOL",
+            "GROVE_OUTPUT_KAFKA_SASL_MECHANISM",
+            "GROVE_OUTPUT_KAFKA_SASL_USERNAME",
+            "GROVE_OUTPUT_KAFKA_SASL_PASSWORD",
+            "GROVE_OUTPUT_KAFKA_MAX_RECORDS_PER_MESSAGE",
+            "GROVE_OUTPUT_KAFKA_MAX_BYTES_PER_MESSAGE",
+            "GROVE_OUTPUT_KAFKA_USE_IDENTITY_AS_KEY",
+        ]:
+            os.environ.pop(key, None)
+
+    def test_setup_success(self):
+        """Ensures the Kafka producer is created with correct configuration."""
+        call_kwargs = _mock_confluent_kafka.Producer.call_args[0][0]
+
+        self.assertEqual(call_kwargs["bootstrap.servers"], "localhost:9092")
+        self.assertEqual(call_kwargs["security.protocol"], "PLAINTEXT")
+        self.assertEqual(call_kwargs["compression.type"], "lz4")
+
+    def test_setup_missing_bootstrap_servers(self):
+        """Ensures ConfigurationException is raised when bootstrap_servers is absent."""
+        os.environ.pop("GROVE_OUTPUT_KAFKA_BOOTSTRAP_SERVERS")
+
+        with self.assertRaises(ConfigurationException):
+            Handler()
+
+    def test_setup_missing_topic(self):
+        """Ensures ConfigurationException is raised when topic is absent."""
+        os.environ.pop("GROVE_OUTPUT_KAFKA_TOPIC")
+
+        with self.assertRaises(ConfigurationException):
+            Handler()
+
+    def test_setup_includes_sasl_when_configured(self):
+        """Ensures SASL fields are included in the producer config when set."""
+        os.environ["GROVE_OUTPUT_KAFKA_SASL_MECHANISM"] = "PLAIN"
+        os.environ["GROVE_OUTPUT_KAFKA_SASL_USERNAME"] = "user"
+        os.environ["GROVE_OUTPUT_KAFKA_SASL_PASSWORD"] = "pass"
+
+        handler = Handler()
+        handler.setup()
+
+        call_kwargs = _mock_confluent_kafka.Producer.call_args[0][0]
+        self.assertEqual(call_kwargs["sasl.mechanism"], "PLAIN")
+        self.assertEqual(call_kwargs["sasl.username"], "user")
+        self.assertEqual(call_kwargs["sasl.password"], "pass")
+
+    def test_submit_success(self):
+        """Ensures produce and flush are called on a successful submit."""
+        data = bytes('{"id":"001","name":"One"}\r\n{"id":"002","name":"Two"}', "utf-8")
+
+        self.handler.submit(
+            data=data,
+            connector="test_connector",
+            identity="test_identity",
+            operation="test_operation",
+        )
+
+        self.mock_producer.produce.assert_called_once()
+        self.mock_producer.flush.assert_called_once_with(30)
+
+    def test_submit_uses_descriptor_as_topic(self):
+        """Ensures descriptor overrides the default topic when producing messages."""
+        data = bytes('{"id":"001"}', "utf-8")
+
+        self.handler.submit(
+            data=data,
+            connector="X",
+            identity="Y",
+            operation="Z",
+            descriptor="custom-topic",
+        )
+
+        topic_arg = self.mock_producer.produce.call_args[0][0]
+        self.assertEqual(topic_arg, "custom-topic")
+
+    def test_submit_uses_default_topic_when_no_descriptor(self):
+        """Ensures the configured topic is used when no descriptor is supplied."""
+        data = bytes('{"id":"001"}', "utf-8")
+
+        self.handler.submit(
+            data=data,
+            connector="X",
+            identity="Y",
+            operation="Z",
+        )
+
+        topic_arg = self.mock_producer.produce.call_args[0][0]
+        self.assertEqual(topic_arg, "grove-logs")
+
+    def test_submit_chunks_by_record_count(self):
+        """Ensures submit splits data when max_records_per_message is exceeded."""
+        os.environ["GROVE_OUTPUT_KAFKA_MAX_RECORDS_PER_MESSAGE"] = "2"
+        handler = Handler()
+        handler.setup()
+
+        lines = [f'{{"id":"{i}"}}' for i in range(5)]
+        data = bytes("\r\n".join(lines), "utf-8")
+
+        handler.submit(
+            data=data,
+            connector="X",
+            identity="Y",
+            operation="Z",
+        )
+
+        # 5 records with max 2 per message → 3 produce calls (2 + 2 + 1).
+        self.assertEqual(self.mock_producer.produce.call_count, 3)
+
+    def test_submit_chunks_by_byte_size(self):
+        """Ensures submit splits data when max_bytes_per_message is exceeded."""
+        os.environ["GROVE_OUTPUT_KAFKA_MAX_BYTES_PER_MESSAGE"] = "20"
+        handler = Handler()
+        handler.setup()
+
+        # Each line is {"id":"0000"} = 13 bytes; line_size = 15 with separator.
+        # max_bytes=20: each chunk holds exactly one line (15 < 20; 15+15=30 > 20).
+        lines = [f'{{"id":"{i:04d}"}}' for i in range(4)]
+        data = bytes("\r\n".join(lines), "utf-8")
+
+        handler.submit(
+            data=data,
+            connector="X",
+            identity="Y",
+            operation="Z",
+        )
+
+        # 4 records, one per chunk → 4 produce calls.
+        self.assertEqual(self.mock_producer.produce.call_count, 4)
+
+    def test_submit_raises_on_delivery_error(self):
+        """Ensures AccessException is raised when a delivery callback reports failure."""
+
+        def side_effect(topic, value=None, key=None, on_delivery=None):
+            if on_delivery is not None:
+                on_delivery("simulated delivery error", MagicMock())
+
+        self.mock_producer.produce.side_effect = side_effect
+
+        data = bytes('{"id":"001"}', "utf-8")
+
+        with self.assertRaises(AccessException):
+            self.handler.submit(
+                data=data,
+                connector="X",
+                identity="Y",
+                operation="Z",
+            )
+
+    def test_submit_raises_on_flush_timeout(self):
+        """Ensures AccessException is raised when flush returns undelivered messages."""
+        self.mock_producer.flush.return_value = 1
+
+        data = bytes('{"id":"001"}', "utf-8")
+
+        with self.assertRaises(AccessException):
+            self.handler.submit(
+                data=data,
+                connector="X",
+                identity="Y",
+                operation="Z",
+            )
+
+    def test_submit_uses_identity_as_key(self):
+        """Ensures the connector identity is used as the Kafka message key."""
+        os.environ["GROVE_OUTPUT_KAFKA_USE_IDENTITY_AS_KEY"] = "true"
+        handler = Handler()
+        handler.setup()
+
+        data = bytes('{"id":"001"}', "utf-8")
+
+        handler.submit(
+            data=data,
+            connector="X",
+            identity="my-identity",
+            operation="Z",
+        )
+
+        produce_kwargs = self.mock_producer.produce.call_args[1]
+        self.assertEqual(produce_kwargs["key"], b"my-identity")
+
+    def test_submit_no_key_by_default(self):
+        """Ensures no message key is set when use_identity_as_key is False."""
+        data = bytes('{"id":"001"}', "utf-8")
+
+        self.handler.submit(
+            data=data,
+            connector="X",
+            identity="Y",
+            operation="Z",
+        )
+
+        produce_kwargs = self.mock_producer.produce.call_args[1]
+        self.assertIsNone(produce_kwargs["key"])
+
+    def test_serialize_returns_plain_ndjson(self):
+        """Ensures serialization produces plain NDJSON bytes, not gzipped."""
+        candidate = [
+            {"id": "0001", "name": "One"},
+            {"id": "0002", "name": "Two"},
+            {"id": "0003", "name": "Three"},
+        ]
+
+        expected_raw = "\r\n".join(
+            [
+                '{"id":"0001","name":"One","_grove":{"field":"value"}}',
+                '{"id":"0002","name":"Two","_grove":{"field":"value"}}',
+                '{"id":"0003","name":"Three","_grove":{"field":"value"}}',
+            ]
+        )
+        expected_raw = bytes(expected_raw, "utf-8")
+
+        result = self.handler.serialize(data=candidate, metadata={"field": "value"})
+
+        self.assertEqual(expected_raw, result)
+        # Verify it is not gzip-compressed (gzip magic bytes are 0x1f 0x8b).
+        self.assertFalse(result[:2] == b"\x1f\x8b")
+
+    def test_serialize_skips_none_entries(self):
+        """Ensures None entries are omitted from the serialized output."""
+        candidate = [{"id": "001"}, None, {"id": "002"}]
+        result = self.handler.serialize(data=candidate)
+        lines = result.split(b"\r\n")
+        self.assertEqual(len(lines), 2)


### PR DESCRIPTION
Adds a new kafka output handler that publishes collected Grove logs to Apache Kafka or Confluent Platform.

- Optional dep: pip install grove[kafka]
- serialize() returns plain NDJSON; Kafka producer handles compression (lz4)
- submit() chunks by max_records_per_message=500 and max_bytes_per_message=750000
- descriptor overrides the default topic for per-operation routing
- use_identity_as_key sets Kafka message key to the connector identity
- Delivery errors and flush timeouts surface as AccessException

Files changed:
- grove/outputs/kafka.py: new output handler
- tests/test_outputs_kafka.py: 15 unit tests
- pyproject.toml: kafka entrypoint and confluent-kafka optional dependency
- docs/configuration.rst: Kafka output configuration reference