### PR TITLE
Update security contact email to hashicorp.security@ibm.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Grove was created and is currently maintained by the HashiCorp security team.
 
 **Please note**: While this is not an official HashiCorp project, security is still very
 important to us! If you have found a potential security issue with Grove, please contact
-us via email at security@hashicorp.com, rather than filing a GitHub issue.
+us via email at hashicorp.security@ibm.com, rather than filing a GitHub issue.
 
 ### Supported Sources
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -28,7 +28,7 @@ Out of the box, Grove provides:
 
 **Please note**: While this is not an official HashiCorp project, security is still very
 important to us! If you have found a potential security issue with Grove, please contact
-us via email at security@hashicorp.com, rather than filing a GitHub issue.
+us via email at hashicorp.security@ibm.com, rather than filing a GitHub issue.
 
 Supported Sources
 -----------------


### PR DESCRIPTION
Replaces `security@hashicorp.com` with `hashicorp.security@ibm.com` across the repo (README.md, docs/index.rst).

Part of an org-wide update of the HashiCorp security contact address.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>